### PR TITLE
Replace Formspree contact form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.txt
+++ b/README.txt
@@ -9,10 +9,12 @@ Using this template
 4. Commit your changes and push to GitHub. The included workflow deploys to GitHub Pages.
 Contact Form Setup
 -------------------
-This site uses a [Formspree](https://formspree.io) endpoint to handle contact form submissions.
-Sign up for Formspree, create a form, and replace `https://formspree.io/f/your-form-id` in the HTML files with your endpoint.
+A small Node.js server handles contact form submissions.
+1. Run `npm install` to install dependencies.
+2. Set environment variables `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` and `CONTACT_EMAIL`.
+3. Start the server with `npm start`.
 
-
+Forms in the HTML files post to `/contact` on this server.
 This is Phantom, a simple design built around a grid of large, colorful, semi-interactive
 image tiles (of which you can have as many or as few as you like). Makes use of some
 SVG and animation techniques I've been experimenting with on that other project of mine

--- a/elements.html
+++ b/elements.html
@@ -282,7 +282,7 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 							<!-- Form -->
 								<section>
 									<h2>Form</h2>
-									<form method="post" action="https://formspree.io/f/your-form-id">
+									<form method="post" action="/contact">
 										<div class="row gtr-uniform">
 											<div class="col-6 col-12-xsmall">
 												<input type="text" name="demo-name" id="demo-name" value="" placeholder="Name" />
@@ -363,7 +363,7 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/generic.html
+++ b/generic.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
                         <div class="inner">
                             <section>
                                 <h2>Get in touch</h2>
-                                <form method="post" action="https://formspree.io/f/xkgbpqwe">
+                                <form method="post" action="/contact">
                                     <div class="fields">
                                         <div class="field half">
                                             <input type="text" name="name" id="name" placeholder="Name" />

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ninvax-site",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.1"
+  }
+}

--- a/projects/barcode-catalog.html
+++ b/projects/barcode-catalog.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/crypto-trading-bot.html
+++ b/projects/crypto-trading-bot.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/cyberpatriot.html
+++ b/projects/cyberpatriot.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/google-cybersecurity.html
+++ b/projects/google-cybersecurity.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/hackathons.html
+++ b/projects/hackathons.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/independent-study.html
+++ b/projects/independent-study.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/mlh-nsa-team.html
+++ b/projects/mlh-nsa-team.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/open-to-work.html
+++ b/projects/open-to-work.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/quantum-curious.html
+++ b/projects/quantum-curious.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/store-associate.html
+++ b/projects/store-associate.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/projects/us-navy-veteran.html
+++ b/projects/us-navy-veteran.html
@@ -58,7 +58,7 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="https://formspree.io/f/your-form-id">
+								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
 											<input type="text" name="name" id="name" placeholder="Name" />

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const nodemailer = require('nodemailer');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.post('/contact', async (req, res) => {
+  const { name, email, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).send('Missing fields');
+  }
+
+  const transport = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  try {
+    await transport.sendMail({
+      from: `${name} <${email}>`,
+      to: process.env.CONTACT_EMAIL,
+      subject: 'Contact Form Submission',
+      text: message
+    });
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ status: 'error' });
+  }
+});
+
+app.use(express.static('.'));
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- host contact form ourselves with Express/Nodemailer
- document how to run the server
- post contact forms to `/contact`

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685c4cb14504833190f9e916449c9441