### PR TITLE
Fix server path and add missing dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "next": "14.2.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "nodemailer": "^6.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ninvax-site",
   "version": "1.0.0",
-  "main": "server.js",
+  "main": "assets/js/server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node assets/js/server.js"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
## Summary
- correct the path to the contact form server in `package.json`
- add `nodemailer` dependency to the Next.js frontend

## Testing
- `npm --version`
- `node --version`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f0f1978833189210c9267fe3d5b