### PR TITLE
Add resume page and navigation

### DIFF
--- a/site/blog.html
+++ b/site/blog.html
@@ -39,6 +39,7 @@
                             <li><a href="projects.html">Projects</a></li>
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
+                            <li><a href="resume.html">Resume</a></li>
                         </ul>
                     </nav>
 

--- a/site/gallery.html
+++ b/site/gallery.html
@@ -39,8 +39,9 @@
                             <li><a href="projects.html">Projects</a></li>
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
+                            <li><a href="resume.html">Resume</a></li>
                         </ul>
-					</nav>
+                    </nav>
 
 				<!-- Main -->
 					<div id="main">

--- a/site/index.html
+++ b/site/index.html
@@ -39,6 +39,7 @@
                             <li><a href="projects.html">Projects</a></li>
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
+                            <li><a href="resume.html">Resume</a></li>
                         </ul>
                     </nav>
 
@@ -80,6 +81,17 @@
                                         <h2>Independent Study</h2>
                                         <div class="content">
                                             <p>Self‑taught Python, Swift and network configuration through online platforms.</p>
+                                        </div>
+                                    </a>
+                                </article>
+                                <article class="style4">
+                                    <span class="image">
+                                        <img src="images/pic09.jpg" alt="" />
+                                    </span>
+                                    <a href="resume.html">
+                                        <h2>Resume</h2>
+                                        <div class="content">
+                                            <p>AI-focused roles and automation experience.</p>
                                         </div>
                                     </a>
                                 </article>

--- a/site/projects.html
+++ b/site/projects.html
@@ -39,8 +39,9 @@
                             <li><a href="projects.html">Projects</a></li>
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
+                            <li><a href="resume.html">Resume</a></li>
                         </ul>
-					</nav>
+                    </nav>
 
 				<!-- Main -->
 					<div id="main">

--- a/site/projects/barcode-catalog.html
+++ b/site/projects/barcode-catalog.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/crypto-trading-bot.html
+++ b/site/projects/crypto-trading-bot.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/cyberpatriot.html
+++ b/site/projects/cyberpatriot.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/google-cybersecurity.html
+++ b/site/projects/google-cybersecurity.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/hackathons.html
+++ b/site/projects/hackathons.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/independent-study.html
+++ b/site/projects/independent-study.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/mlh-nsa-team.html
+++ b/site/projects/mlh-nsa-team.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/open-to-work.html
+++ b/site/projects/open-to-work.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/quantum-curious.html
+++ b/site/projects/quantum-curious.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/store-associate.html
+++ b/site/projects/store-associate.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/projects/us-navy-veteran.html
+++ b/site/projects/us-navy-veteran.html
@@ -39,6 +39,7 @@
 							<li><a href="../projects.html">Projects</a></li>
 							<li><a href="../gallery.html">Gallery</a></li>
                                 <li><a href="../blog.html">Blog</a></li>
+                                                        <li><a href="../resume.html">Resume</a></li>
 						</ul>
 					</nav>
 

--- a/site/resume.html
+++ b/site/resume.html
@@ -1,0 +1,156 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+               <title>Ninvax - Resume</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="stylesheet" href="assets/css/main.css" />
+                <link rel="icon" type="image/svg+xml" href="images/logo.svg" />
+		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+	</head>
+	<body class="is-preload">
+		<!-- Wrapper -->
+			<div id="wrapper">
+
+				<!-- Header -->
+					<header id="header">
+						<div class="inner">
+
+							<!-- Logo -->
+								<a href="index.html" class="logo">
+									<span class="symbol"><img src="images/logo.svg" alt="" /></span><span class="title">ninvax</span>
+								</a>
+
+							<!-- Nav -->
+								<nav>
+									<ul>
+										<li><a href="#menu">Menu</a></li>
+									</ul>
+								</nav>
+
+						</div>
+					</header>
+
+				<!-- Menu -->
+                                        <nav id="menu">
+                                                <h2>Menu</h2>
+                                                <ul>
+                                                        <li><a href="index.html">Home</a></li>
+                                                        <li><a href="projects.html">Projects</a></li>
+                                                        <li><a href="gallery.html">Gallery</a></li>
+                                                        <li><a href="blog.html">Blog</a></li>
+                                                        <li><a href="resume.html">Resume</a></li>
+                                                </ul>
+                                        </nav>
+
+				<!-- Main -->
+					<div id="main">
+						<div class="inner">
+							<h1>Resume</h1>
+                                                        <span class="image main"><img src="images/pic09.jpg" alt="" /></span>
+                                                        <section>
+                                                            <h2>AI Prompt Engineer / Cognitive Systems Designer</h2>
+                                                            <p><strong>Role:</strong> AI Prompt Engineer &amp; Cognitive Systems Architect<br>
+                                                            <strong>Alias:</strong> Ninvax<br>
+                                                            <strong>Duration:</strong> Ongoing / 2023&ndash;Present<br>
+                                                            <strong>Location:</strong> Remote / Self-Initiated<br>
+                                                            <strong>Type:</strong> Freelance / Independent Researcher</p>
+
+                                                            <h3>Summary</h3>
+                                                            <p>Developed advanced prompt frameworks, simulated multi-agent interactions, and engineered human-AI dialogue systems. Applied psychological modeling and language precision to elicit high-quality outputs from large language models. Specialized in creating tools that externalize thought, mirror cognition, and augment human capability.</p>
+
+                                                            <h3>Key Contributions</h3>
+                                                            <ul>
+                                                                <li>Engineered custom GPT-based assistants with persistent memory and multi-modal context integration</li>
+                                                                <li>Designed system prompts that reflect complex identities, emotional states, and philosophical perspectives</li>
+                                                                <li>Built AI-powered workflows that assist in decision-making, personal productivity, and mental health insight</li>
+                                                                <li>Researched behavioral prompt patterns to simulate internal dialogues, improve creativity, and reduce cognitive friction</li>
+                                                                <li>Integrated prompt engineering into apps (iOS/Xcode), Discord bots, and automated personal tools</li>
+                                                            </ul>
+
+                                                            <h3>Tools</h3>
+                                                            <p>OpenAI API (GPT-4, GPT-4o), Auto-GPT, Apple Shortcuts, Python, SwiftUI, Discord.py, Drafts App, Notion AI, Raycast</p>
+                                                        </section>
+
+                                                        <section>
+                                                            <h2>AI Tool Engineer / Automation Architect</h2>
+                                                            <p><strong>Role:</strong> AI Tool Engineer &amp; Workflow Automator<br>
+                                                            <strong>Alias:</strong> Ninvax<br>
+                                                            <strong>Duration:</strong> 2022&ndash;Present<br>
+                                                            <strong>Location:</strong> Remote / Independent Projects</p>
+
+                                                            <h3>Summary</h3>
+                                                            <p>Created modular, AI-integrated tools to streamline digital life, simulate behavior, and prototype intelligent interfaces. Blended software development with psychological design thinking to build dynamic tools for real-time use.</p>
+
+                                                            <h3>Key Contributions</h3>
+                                                            <ul>
+                                                                <li>Built AI-powered automations for file parsing, calendar syncing, journaling, task tracking, and data labeling</li>
+                                                                <li>Developed Discord bots with OpenAI integration for emotional support, server management, and persona activation</li>
+                                                                <li>Prototyped apps that transform real-world experiences into game-like systems using AI logic</li>
+                                                                <li>Architected personalized digital systems that serve as external cognitive scaffolding for users with ADHD and PTSD</li>
+                                                            </ul>
+
+                                                            <h3>Tech Stack</h3>
+                                                            <p>Python, SwiftUI, Xcode, Apple Shortcuts, Discord API, Raycast, Drafts, iOS automation, JSON, CoreML, OCR</p>
+                                                        </section>
+
+                                                        <section>
+                                                            <h2>Summary Line</h2>
+                                                            <p>AI Prompt Engineer | Cognitive Systems Architect | Workflow Automator | Self-Directed Technomancer &mdash; Specializing in human-AI interface design, thought simulation, and automating the invisible.</p>
+                                                        </section>
+						</div>
+					</div>
+
+				<!-- Footer -->
+					<footer id="footer">
+						<div class="inner">
+							<section>
+								<h2>Get in touch</h2>
+								<form method="post" action="/contact">
+									<div class="fields">
+										<div class="field half">
+											<input type="text" name="name" id="name" placeholder="Name" />
+										</div>
+										<div class="field half">
+											<input type="email" name="email" id="email" placeholder="Email" />
+										</div>
+										<div class="field">
+											<textarea name="message" id="message" placeholder="Message"></textarea>
+										</div>
+									</div>
+									<ul class="actions">
+										<li><input type="submit" value="Send" class="primary" /></li>
+									</ul>
+								</form>
+							</section>
+							<section>
+								<h2>Follow</h2>
+								<ul class="icons">
+									<li><a href="https://x.com/ninvaxxx" class="icon brands style2 fa-twitter"><span class="label">X</span></a></li>
+                                <li><a href="https://vsco.co/ninvaxxx" class="icon solid style2 fa-camera"><span class="label">VSCO</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-facebook-f"><span class="label">Facebook</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-instagram"><span class="label">Instagram</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-dribbble"><span class="label">Dribbble</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-github"><span class="label">GitHub</span></a></li>
+									<li><a href="#" class="icon brands style2 fa-500px"><span class="label">500px</span></a></li>
+									<li><a href="#" class="icon solid style2 fa-phone"><span class="label">Phone</span></a></li>
+									<li><a href="#" class="icon solid style2 fa-envelope"><span class="label">Email</span></a></li>
+								</ul>
+							</section>
+							<ul class="copyright">
+                                                               <li>&copy; Ninvax. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+							</ul>
+						</div>
+					</footer>
+
+			</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+			<script src="assets/js/util.js"></script>
+			<script src="assets/js/main.js"></script>
+
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- add detailed resume page with AI-focused roles
- link resume from site navigation
- add resume tile on homepage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fd730c4dc833193b4cfb1ed23c669