### PR TITLE
Improve home page with project showcase

### DIFF
--- a/frontend/components/ProjectCard.js
+++ b/frontend/components/ProjectCard.js
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function ProjectCard({ title, description, image, codeLink, projectLink }) {
+  return (
+    <div style={{ border: '1px solid #ddd', borderRadius: '8px', overflow: 'hidden', width: '300px', margin: '1rem' }}>
+      {image && (
+        <div style={{ position: 'relative', height: '180px' }}>
+          <Image src={image} alt={title} fill style={{ objectFit: 'cover' }} />
+        </div>
+      )}
+      <div style={{ padding: '1rem' }}>
+        <h3>{title}</h3>
+        <p>{description}</p>
+        <p>
+          {codeLink && (
+            <a href={codeLink} target="_blank" rel="noopener noreferrer">Source</a>
+          )}
+          {projectLink && (
+            <>
+              {' '}|{' '}
+              <Link href={projectLink}>Details</Link>
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Schedule.js
+++ b/frontend/components/Schedule.js
@@ -1,0 +1,14 @@
+export default function Schedule() {
+  return (
+    <div style={{ marginTop: '2rem', textAlign: 'center' }}>
+      <h2>Schedule Tech Help</h2>
+      <iframe
+        src="YOUR_GOOGLE_CALENDAR_URL"
+        style={{ border: 0 }}
+        width="800"
+        height="600"
+        frameBorder="0"
+      ></iframe>
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,6 +1,32 @@
 import Head from 'next/head';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
+import ProjectCard from '../components/ProjectCard';
+import Schedule from '../components/Schedule';
+
+const projects = [
+  {
+    title: 'Crypto Trading Bot',
+    description: 'Python automation for algorithmic trading using the Binance API.',
+    image: '/pic01.jpg',
+    codeLink: 'https://github.com/Ninvaxx/crypto-trading-bot',
+    projectLink: '/projects/crypto-trading-bot.html',
+  },
+  {
+    title: 'Barcode Catalog',
+    description: 'iOS app to track store inventory with Swift.',
+    image: '/pic02.jpg',
+    codeLink: 'https://github.com/Ninvaxx/barcode-catalog',
+    projectLink: '/projects/barcode-catalog.html',
+  },
+  {
+    title: 'Independent Study',
+    description: 'Self‑taught Python, Swift and network configuration.',
+    image: '/pic04.jpg',
+    codeLink: 'https://github.com/Ninvaxx',
+    projectLink: '/projects/independent-study.html',
+  },
+];
 
 export default function Home() {
   return (
@@ -11,9 +37,19 @@ export default function Home() {
         <link rel="icon" href="/logo.svg" />
       </Head>
       <Navbar />
-      <main style={{ padding: '2rem', textAlign: 'center' }}>
-        <h1>Welcome to Ninvax</h1>
-        <p>Site under construction.</p>
+      <main style={{ padding: '2rem' }}>
+        <h1 style={{ textAlign: 'center' }}>Welcome to Ninvax</h1>
+        <p style={{ textAlign: 'center' }}>
+          Cybersecurity specialist, nuclear Navy veteran and data analyst. I build
+          and break systems to protect what matters and design tools for minds like
+          mine.
+        </p>
+        <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
+          {projects.map((proj) => (
+            <ProjectCard key={proj.title} {...proj} />
+          ))}
+        </div>
+        <Schedule />
       </main>
       <Footer />
     </>

--- a/frontend/public/pic01.jpg
+++ b/frontend/public/pic01.jpg
@@ -1,0 +1,1 @@
+../../site/images/pic01.jpg

--- a/frontend/public/pic02.jpg
+++ b/frontend/public/pic02.jpg
@@ -1,0 +1,1 @@
+../../site/images/pic02.jpg

--- a/frontend/public/pic04.jpg
+++ b/frontend/public/pic04.jpg
@@ -1,0 +1,1 @@
+../../site/images/pic04.jpg


### PR DESCRIPTION
## Summary
- create ProjectCard and Schedule components
- improve home page content with project highlights
- embed scheduling iframe
- link to existing images using symlinks to avoid binary files

## Testing
- `npm run build` *(fails: next not found because dependencies aren't installed)*
- `npm install` *(fails: 403 Forbidden due to no network)*
- `npm install` in `site/` *(fails: 403 Forbidden due to no network)*


------
https://chatgpt.com/codex/tasks/task_e_685fe8dc07948331954436933fce5e56