### PR TITLE
Remove Instagram preview from gallery

### DIFF
--- a/site/gallery.html
+++ b/site/gallery.html
@@ -49,10 +49,10 @@
                                                         <h1>Gallery</h1>
 							<span class="image main"><img src="images/pic13.jpg" alt="" /></span>
                                                         <p>A collection of screenshots and photos will go here.</p>
-                                                        <section>
+                                                        <!-- <section>
                                                             <h2>Instagram</h2>
                                                             <iframe src="https://www.instagram.com/ninvax/embed" width="100%" height="400" frameborder="0" loading="lazy"></iframe>
-                                                        </section>
+                                                        </section> -->
                                                         <section>
                                                             <h2>VSCO</h2>
                                                             <iframe src="https://vsco.co/ninvaxxx/gallery" width="100%" height="400" frameborder="0" loading="lazy"></iframe>


### PR DESCRIPTION
## Summary
- comment out Instagram embed on gallery page

## Testing
- `grep -n "<h2>Instagram" -n site/gallery.html`

------
https://chatgpt.com/codex/tasks/task_e_68628643645c8331ba2038686922db7c