### PR TITLE
Add dynamic GraphContext execution

### DIFF
--- a/code-engine-core/graph.json
+++ b/code-engine-core/graph.json
@@ -1,7 +1,21 @@
 {
   "nodes": [
-    { "id": "start", "type": "start", "next": "add" },
-    { "id": "add", "type": "math:add", "inputs": [3, 5], "next": "print" },
-    { "id": "print", "type": "print" }
+    { "id": "start", "type": "start", "next": "num1" },
+    { "id": "num1", "type": "value", "value": 3, "next": "num2" },
+    { "id": "num2", "type": "value", "value": 5, "next": "add" },
+    {
+      "id": "add",
+      "type": "math:add",
+      "inputs": {
+        "a": { "from": "num1" },
+        "b": { "from": "num2" }
+      },
+      "next": "print"
+    },
+    {
+      "id": "print",
+      "type": "print",
+      "inputs": { "value": { "from": "add" } }
+    }
   ]
 }

--- a/code-engine-core/src/main.rs
+++ b/code-engine-core/src/main.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 
 use serde::Deserialize;
+use serde_json::Value;
 
 #[derive(Deserialize, Debug)]
 struct Graph {
@@ -11,19 +12,19 @@ struct Graph {
 #[derive(Deserialize, Debug)]
 struct Node {
     id: String,
-    #[serde(flatten)]
-    kind: NodeKind,
+    #[serde(rename = "type")]
+    node_type: String,
+    #[serde(default)]
+    inputs: HashMap<String, InputSpec>,
+    next: Option<String>,
+    value: Option<Value>,
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(tag = "type")]
-enum NodeKind {
-    #[serde(rename = "start")]
-    Start { next: String },
-    #[serde(rename = "print")]
-    Print { next: Option<String> },
-    #[serde(rename = "math:add")]
-    MathAdd { inputs: Vec<i64>, next: String },
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+enum InputSpec {
+    From { from: String },
+    Value(Value),
 }
 
 impl Graph {
@@ -37,31 +38,91 @@ impl Graph {
     }
 }
 
+#[derive(Default)]
+struct GraphContext {
+    values: HashMap<String, Value>,
+}
+
+impl GraphContext {
+    fn set(&mut self, key: &str, value: Value) {
+        self.values.insert(key.to_string(), value);
+    }
+
+    fn get(&self, key: &str) -> Option<&Value> {
+        self.values.get(key)
+    }
+}
+
+fn resolve_input(spec: &InputSpec, ctx: &GraphContext) -> Option<Value> {
+    match spec {
+        InputSpec::From { from } => ctx.get(from).cloned(),
+        InputSpec::Value(v) => Some(v.clone()),
+    }
+}
+
 fn run_graph(graph: &Graph) {
     let map = graph.node_map();
-    // find start node
-    let mut current = graph.nodes.iter().find(|n| matches!(n.kind, NodeKind::Start { .. }));
-    let mut value: Option<i64> = None;
+    let mut ctx = GraphContext::default();
+    let mut current = graph
+        .nodes
+        .iter()
+        .find(|n| n.node_type == "start");
 
     while let Some(node) = current {
-        match &node.kind {
-            NodeKind::Start { next } => {
-                println!("Start -> {}", next);
-                current = map.get(next.as_str()).copied();
+        match node.node_type.as_str() {
+            "start" => {
+                current = node
+                    .next
+                    .as_deref()
+                    .and_then(|n| map.get(n))
+                    .copied();
             }
-            NodeKind::MathAdd { inputs, next } => {
-                let sum: i64 = inputs.iter().sum();
-                println!("Add {:?} = {}", inputs, sum);
-                value = Some(sum);
-                current = map.get(next.as_str()).copied();
+            "value" => {
+                let val = node.value.clone().unwrap_or(Value::Null);
+                ctx.set(&node.id, val.clone());
+                current = node
+                    .next
+                    .as_deref()
+                    .and_then(|n| map.get(n))
+                    .copied();
             }
-            NodeKind::Print { next } => {
-                if let Some(v) = value {
-                    println!("Print: {}", v);
+            "math:add" => {
+                let a = node.inputs.get("a").and_then(|s| resolve_input(s, &ctx));
+                let b = node.inputs.get("b").and_then(|s| resolve_input(s, &ctx));
+                let a = a.and_then(|v| v.as_i64());
+                let b = b.and_then(|v| v.as_i64());
+                if let (Some(x), Some(y)) = (a, b) {
+                    let sum = x + y;
+                    println!("Add {} + {} = {}", x, y, sum);
+                    ctx.set(&node.id, Value::from(sum));
                 } else {
-                    println!("Print node with no value");
+                    println!("Add node missing inputs");
                 }
-                current = next.as_deref().and_then(|n| map.get(n)).copied();
+                current = node
+                    .next
+                    .as_deref()
+                    .and_then(|n| map.get(n))
+                    .copied();
+            }
+            "print" => {
+                if let Some(spec) = node.inputs.get("value") {
+                    if let Some(v) = resolve_input(spec, &ctx) {
+                        println!("Print: {}", v);
+                    } else {
+                        println!("Print: null");
+                    }
+                } else {
+                    println!("Print node with no input");
+                }
+                current = node
+                    .next
+                    .as_deref()
+                    .and_then(|n| map.get(n))
+                    .copied();
+            }
+            other => {
+                println!("Unknown node type: {}", other);
+                current = None;
             }
         }
     }


### PR DESCRIPTION
## Summary
- introduce `GraphContext` to store node outputs
- allow inputs to come from constants or other node results
- update `graph.json` to demonstrate value nodes feeding an add node
- refactor execution to resolve inputs dynamically

## Testing
- `cargo check --offline` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687643cda870833198e6a68a494272cb