### PR TITLE
Add simple branching support

### DIFF
--- a/code-engine-core/graph_if.json
+++ b/code-engine-core/graph_if.json
@@ -1,0 +1,16 @@
+{
+  "nodes": [
+    { "id": "start", "type": "start", "next": "val_true" },
+    { "id": "val_true", "type": "value", "value": true, "next": "val_false" },
+    { "id": "val_false", "type": "value", "value": false, "next": "branch" },
+    {
+      "id": "branch",
+      "type": "if",
+      "inputs": { "condition": { "from": "val_true" } },
+      "next_then": "print_true",
+      "next_else": "print_false"
+    },
+    { "id": "print_true", "type": "print", "inputs": { "value": { "from": "val_true" } } },
+    { "id": "print_false", "type": "print", "inputs": { "value": { "from": "val_false" } } }
+  ]
+}


### PR DESCRIPTION
## Summary
- enable branching via new `if` node in the engine
- allow `GraphContext` to read boolean values
- parse new branch pointers in the graph
- add example `graph_if.json` demonstrating true/false conditional

## Testing
- `cargo build` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687646ff0fec8331859cdd0c27d72cec