### PR TITLE
Add Lua script node to engine

### DIFF
--- a/code-engine-core/Cargo.toml
+++ b/code-engine-core/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+mlua = { version = "0.9", features = ["lua54", "serialize"] }

--- a/code-engine-core/graph_lua.json
+++ b/code-engine-core/graph_lua.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    { "id": "start", "type": "start", "next": "num1" },
+    { "id": "num1", "type": "value", "value": 2, "next": "num2" },
+    { "id": "num2", "type": "value", "value": 7, "next": "lua_add" },
+    {
+      "id": "lua_add",
+      "type": "script:lua",
+      "code": "return a + b",
+      "variables": {
+        "a": { "from": "num1" },
+        "b": { "from": "num2" }
+      },
+      "next": "print"
+    },
+    { "id": "print", "type": "print", "inputs": { "value": { "from": "lua_add" } } }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `mlua` dependency with Lua54 and serde features
- introduce new node fields for script code and variables
- implement `script:lua` node execution using embedded Lua VM
- provide `graph_lua.json` example demonstrating Lua addition

## Testing
- `cargo build` *(fails: missing crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68764c7856dc8331ac41c5246238b202