### PR TITLE
Add loop and tick engine

### DIFF
--- a/code-engine-core/graph_tick_loop.json
+++ b/code-engine-core/graph_tick_loop.json
@@ -1,0 +1,21 @@
+{
+  "nodes": [
+    { "id": "start", "type": "start", "next": "val" },
+    { "id": "val", "type": "value", "value": 1, "next": "loop" },
+    {
+      "id": "loop",
+      "type": "loop",
+      "count": 5,
+      "next_body": "print",
+      "next_exit": "end"
+    },
+    {
+      "id": "print",
+      "type": "print",
+      "inputs": { "value": { "from": "val" } },
+      "next": "delay"
+    },
+    { "id": "delay", "type": "delay", "ticks": 1, "next": "loop" },
+    { "id": "end", "type": "value", "value": 0 }
+  ]
+}

--- a/code-engine-core/src/main.rs
+++ b/code-engine-core/src/main.rs
@@ -29,6 +29,14 @@ struct Node {
     #[serde(default)]
     next_else: Option<String>,
     value: Option<Value>,
+    #[serde(default)]
+    count: Option<i64>,
+    #[serde(default)]
+    ticks: Option<i64>,
+    #[serde(default)]
+    next_body: Option<String>,
+    #[serde(default)]
+    next_exit: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -75,75 +83,100 @@ fn resolve_input(spec: &InputSpec, ctx: &GraphContext) -> Option<Value> {
     }
 }
 
-fn run_graph(graph: &Graph, ctx: &mut GraphContext) {
-    let map = graph.node_map();
-    let mut current = graph
-        .nodes
-        .iter()
-        .find(|n| n.node_type == "start");
+use std::collections::VecDeque;
 
-    while let Some(node) = current {
+struct Engine {
+    graph: Graph,
+    ctx: GraphContext,
+    map: HashMap<String, usize>,
+    current: Option<String>,
+    loop_state: HashMap<String, i64>,
+    delay_queue: Vec<(i64, String)>,
+    ready: VecDeque<String>,
+    tick: u64,
+}
+
+impl Engine {
+    fn new(graph: Graph) -> Self {
+        let map = graph
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.id.clone(), i))
+            .collect();
+        let current = graph
+            .nodes
+            .iter()
+            .find(|n| n.node_type == "start")
+            .map(|n| n.id.clone());
+        Engine {
+            graph,
+            ctx: GraphContext::default(),
+            map,
+            current,
+            loop_state: HashMap::new(),
+            delay_queue: Vec::new(),
+            ready: VecDeque::new(),
+            tick: 0,
+        }
+    }
+
+    fn with_context(graph: Graph, ctx: GraphContext) -> Self {
+        let mut eng = Engine::new(graph);
+        eng.ctx = ctx;
+        eng
+    }
+
+    fn get_node(&self, id: &str) -> Option<&Node> {
+        self.map.get(id).and_then(|&i| self.graph.nodes.get(i))
+    }
+
+    fn process_node(&mut self, id: String) -> bool {
+        let node = match self.get_node(&id) {
+            Some(n) => n,
+            None => return false,
+        };
         match node.node_type.as_str() {
             "start" => {
-                current = node
-                    .next
-                    .as_deref()
-                    .and_then(|n| map.get(n))
-                    .copied();
+                self.current = node.next.clone();
             }
             "value" => {
                 let val = node.value.clone().unwrap_or(Value::Null);
-                ctx.set(&node.id, val.clone());
-                current = node
-                    .next
-                    .as_deref()
-                    .and_then(|n| map.get(n))
-                    .copied();
+                self.ctx.set(&node.id, val);
+                self.current = node.next.clone();
             }
             "math:add" => {
-                let a = node.inputs.get("a").and_then(|s| resolve_input(s, &ctx));
-                let b = node.inputs.get("b").and_then(|s| resolve_input(s, &ctx));
+                let a = node.inputs.get("a").and_then(|s| resolve_input(s, &self.ctx));
+                let b = node.inputs.get("b").and_then(|s| resolve_input(s, &self.ctx));
                 let a = a.and_then(|v| v.as_i64());
                 let b = b.and_then(|v| v.as_i64());
                 if let (Some(x), Some(y)) = (a, b) {
                     let sum = x + y;
-                    println!("Add {} + {} = {}", x, y, sum);
-                    ctx.set(&node.id, Value::from(sum));
+                    println!("[tick {}] Add {} + {} = {}", self.tick, x, y, sum);
+                    self.ctx.set(&node.id, Value::from(sum));
                 } else {
-                    println!("Add node missing inputs");
+                    println!("[tick {}] Add node missing inputs", self.tick);
                 }
-                current = node
-                    .next
-                    .as_deref()
-                    .and_then(|n| map.get(n))
-                    .copied();
+                self.current = node.next.clone();
             }
             "if" => {
-                let cond = node.inputs.get("condition").and_then(|s| resolve_input(s, &ctx));
+                let cond = node.inputs.get("condition").and_then(|s| resolve_input(s, &self.ctx));
                 let cond = cond.and_then(|v| v.as_bool()).unwrap_or(false);
-                ctx.set(&node.id, Value::Bool(cond));
-                let next_id = if cond {
-                    node.next_then.as_deref()
-                } else {
-                    node.next_else.as_deref()
-                };
-                current = next_id.and_then(|n| map.get(n)).copied();
+                self.ctx.set(&node.id, Value::Bool(cond));
+                let next_id = if cond { node.next_then.as_deref() } else { node.next_else.as_deref() };
+                self.current = next_id.map(|s| s.to_string());
             }
             "print" => {
                 if let Some(spec) = node.inputs.get("value") {
-                    if let Some(v) = resolve_input(spec, &ctx) {
-                        println!("Print: {}", v);
+                    if let Some(v) = resolve_input(spec, &self.ctx) {
+                        println!("[tick {}] Print: {}", self.tick, v);
                     } else {
-                        println!("Print: null");
+                        println!("[tick {}] Print: null", self.tick);
                     }
                 } else {
-                    println!("Print node with no input");
+                    println!("[tick {}] Print node with no input", self.tick);
                 }
-                current = node
-                    .next
-                    .as_deref()
-                    .and_then(|n| map.get(n))
-                    .copied();
+                self.current = node.next.clone();
             }
             "script:lua" => {
                 let code = node.code.as_deref().unwrap_or("");
@@ -151,7 +184,7 @@ fn run_graph(graph: &Graph, ctx: &mut GraphContext) {
                 {
                     let globals = lua.globals();
                     for (name, spec) in &node.variables {
-                        if let Some(val) = resolve_input(spec, &ctx) {
+                        if let Some(val) = resolve_input(spec, &self.ctx) {
                             if let Ok(lua_val) = lua.to_value(&val) {
                                 let _ = globals.set(name.as_str(), lua_val);
                             }
@@ -165,27 +198,85 @@ fn run_graph(graph: &Graph, ctx: &mut GraphContext) {
                 let json_val: Value = lua
                     .from_value(result)
                     .unwrap_or(Value::Null);
-                ctx.set(&node.id, json_val);
-                current = node
-                    .next
-                    .as_deref()
-                    .and_then(|n| map.get(n))
-                    .copied();
+                self.ctx.set(&node.id, json_val);
+                self.current = node.next.clone();
+            }
+            "delay" => {
+                let ticks = node.ticks.unwrap_or(0);
+                if let Some(next) = node.next.clone() {
+                    self.delay_queue.push((ticks, next));
+                }
+                self.current = None;
+                return false;
+            }
+            "loop" => {
+                let total = node.count.unwrap_or(0);
+                let entry = self.loop_state.entry(node.id.clone()).or_insert(total);
+                if *entry > 0 {
+                    *entry -= 1;
+                    self.current = node.next_body.clone();
+                } else {
+                    self.loop_state.remove(&node.id);
+                    self.current = node.next_exit.clone();
+                }
             }
             other => {
-                println!("Unknown node type: {}", other);
-                current = None;
+                println!("[tick {}] Unknown node type: {}", self.tick, other);
+                self.current = None;
             }
         }
+        true
+    }
+
+    fn tick(&mut self) -> bool {
+        self.tick += 1;
+        // update delay queue
+        let mut ready = Vec::new();
+        for i in 0..self.delay_queue.len() {
+            if self.delay_queue[i].0 > 0 {
+                self.delay_queue[i].0 -= 1;
+            }
+            if self.delay_queue[i].0 <= 0 {
+                ready.push(i);
+            }
+        }
+        // extract ready nodes in reverse order
+        for idx in ready.into_iter().rev() {
+            let (_t, id) = self.delay_queue.remove(idx);
+            self.ready.push_back(id);
+        }
+
+        if self.current.is_none() {
+            if let Some(id) = self.ready.pop_front() {
+                self.current = Some(id);
+            }
+        }
+
+        while let Some(id) = self.current.clone() {
+            if !self.process_node(id) {
+                break;
+            }
+            if self.current.is_none() {
+                if let Some(next_id) = self.ready.pop_front() {
+                    self.current = Some(next_id);
+                }
+            }
+        }
+
+        self.current.is_some() || !self.delay_queue.is_empty() || !self.ready.is_empty()
+    }
+
+    fn run(&mut self) {
+        while self.tick() {}
     }
 }
 
-fn inspect(graph: &Option<Graph>, ctx: &GraphContext) {
-    match graph {
-        Some(g) => {
+fn inspect(engine: &Option<Engine>) {
+    match engine {
+        Some(e) => {
             println!("Graph nodes:");
-            for n in &g.nodes {
-                if let Some(v) = ctx.get(&n.id) {
+            for n in &e.graph.nodes {
+                if let Some(v) = e.ctx.get(&n.id) {
                     println!("- {} ({}) => {}", n.id, n.node_type, v);
                 } else {
                     println!("- {} ({})", n.id, n.node_type);
@@ -197,8 +288,7 @@ fn inspect(graph: &Option<Graph>, ctx: &GraphContext) {
 }
 
 fn repl() {
-    let mut graph: Option<Graph> = None;
-    let mut ctx = GraphContext::default();
+    let mut engine: Option<Engine> = None;
     let stdin = io::stdin();
     loop {
         print!("repl> ");
@@ -219,8 +309,7 @@ fn repl() {
                 if let Some(path) = parts.next() {
                     match Graph::from_file(path) {
                         Ok(g) => {
-                            graph = Some(g);
-                            ctx = GraphContext::default();
+                            engine = Some(Engine::new(g));
                             println!("Loaded {}", path);
                         }
                         Err(e) => println!("Error loading graph: {}", e),
@@ -230,35 +319,52 @@ fn repl() {
                 }
             }
             "run" => {
-                if let Some(ref g) = graph {
-                    run_graph(g, &mut ctx);
+                if let Some(e) = engine.as_mut() {
+                    e.run();
+                } else {
+                    println!("No graph loaded");
+                }
+            }
+            "tick" => {
+                if let Some(e) = engine.as_mut() {
+                    if !e.tick() {
+                        println!("Graph finished");
+                    }
                 } else {
                     println!("No graph loaded");
                 }
             }
             "inspect" => {
-                inspect(&graph, &ctx);
+                inspect(&engine);
             }
             "set" => {
                 let key = parts.next();
                 let value_str = parts.collect::<Vec<_>>().join(" ");
-                if let (Some(k), true) = (key, !value_str.is_empty()) {
-                    match serde_json::from_str(&value_str) {
-                        Ok(v) => {
-                            ctx.set(k, v);
-                            println!("Set {}", k);
+                if let Some(e) = engine.as_mut() {
+                    if let (Some(k), true) = (key, !value_str.is_empty()) {
+                        match serde_json::from_str(&value_str) {
+                            Ok(v) => {
+                                e.ctx.set(k, v);
+                                println!("Set {}", k);
+                            }
+                            Err(e2) => println!("Failed to parse value: {}", e2),
                         }
-                        Err(e) => println!("Failed to parse value: {}", e),
+                    } else {
+                        println!("Usage: set <key> <json value>");
                     }
                 } else {
-                    println!("Usage: set <key> <json value>");
+                    println!("No graph loaded");
                 }
             }
             "save" => {
                 if let Some(path) = parts.next() {
-                    match fs::write(path, serde_json::to_string_pretty(&ctx.values).unwrap_or_default()) {
-                        Ok(_) => println!("Context saved to {}", path),
-                        Err(e) => println!("Failed to save: {}", e),
+                    if let Some(e) = &engine {
+                        match fs::write(path, serde_json::to_string_pretty(&e.ctx.values).unwrap_or_default()) {
+                            Ok(_) => println!("Context saved to {}", path),
+                            Err(e2) => println!("Failed to save: {}", e2),
+                        }
+                    } else {
+                        println!("No graph loaded");
                     }
                 } else {
                     println!("Usage: save <file>");
@@ -266,7 +372,7 @@ fn repl() {
             }
             "exit" | "quit" => break,
             "help" => {
-                println!("Commands: load <file>, run, inspect, set <key> <value>, save <file>, quit");
+                println!("Commands: load <file>, run, tick, inspect, set <key> <value>, save <file>, quit");
             }
             _ => println!("Unknown command"),
         }
@@ -289,8 +395,8 @@ fn main() {
         repl();
     } else {
         let graph = Graph::from_file(&cli.file).expect("failed to parse graph");
-        let mut ctx = GraphContext::default();
-        run_graph(&graph, &mut ctx);
+        let mut engine = Engine::new(graph);
+        engine.run();
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `Node` struct with loop/delay fields
- implement new `Engine` with tick-based execution
- support `loop` and `delay` nodes
- add `tick` command to REPL
- provide `graph_tick_loop.json` example

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6876534be52083318d4086a6f5ccf42f