### PR TITLE
Add self-feedback scaffolding

### DIFF
--- a/ai_bot/bootstrap.py
+++ b/ai_bot/bootstrap.py
@@ -3,9 +3,13 @@
 from pathlib import Path
 import yaml
 
+from brain.thoughts import log_thought
+from tools.code_tester import run_tests
+
 from inputs.web_scraper import scrape_site
 from brain.planner import plan
 from tools.code_writer import write_file
+from tools.evaluate import evaluate_thoughts
 
 CONFIG_FILE = Path(__file__).with_name("core_config.yaml")
 
@@ -18,15 +22,30 @@ def load_config() -> dict:
 
 def main() -> None:
     config = load_config()
+    testing_enabled = config.get("testing_enabled", True)
+    log_thoughts = config.get("log_thoughts", False)
+    auto_evaluate = config.get("auto_evaluate", False)
     url = config.get("start_url", "https://example.com")
     data = scrape_site(url)
+    if log_thoughts:
+        log_thought(f"Scraped data from {url}\n\n{data}", tag="scrape")
     action_plan = plan(data)
+    if log_thoughts:
+        log_thought(str(action_plan), tag="plan")
 
     if action_plan.get("action") == "write_code":
         output_path = Path(__file__).with_name("generated.txt")
-        write_file(output_path, action_plan.get("content", ""))
+        content = action_plan.get("content", "")
+        write_file(output_path, content)
         print(f"Wrote plan output to {output_path}")
+        if log_thoughts:
+            log_thought(content, tag="code")
+        if testing_enabled and action_plan.get("testable"):
+            run_tests(output_path)
+    if auto_evaluate and log_thoughts:
+        evaluate_thoughts(Path(__file__).with_name("brain").joinpath("thoughts"))
 
 
 if __name__ == "__main__":
     main()
+

--- a/ai_bot/brain/memory/__init__.py
+++ b/ai_bot/brain/memory/__init__.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import json
+
+MEMORY_PATH = Path(__file__).with_name("memory_log.json")
+
+
+def load_memory() -> dict:
+    if MEMORY_PATH.exists():
+        return json.loads(MEMORY_PATH.read_text())
+    return {}
+
+
+def update_memory(entry: dict) -> None:
+    data = load_memory()
+    data.update(entry)
+    MEMORY_PATH.write_text(json.dumps(data, indent=2))
+

--- a/ai_bot/brain/planner.py
+++ b/ai_bot/brain/planner.py
@@ -2,6 +2,11 @@
 
 from typing import Any
 
+
+def _is_testable(content: str) -> bool:
+    """Very small heuristic to determine if code has testable functions."""
+    return "def " in content
+
 def plan(data: str) -> Any:
     """Simulate planning based on scraped data.
 
@@ -13,4 +18,10 @@ def plan(data: str) -> Any:
     """
     print("Planning next steps ...")
     # In a real implementation this would contain actual planning logic.
-    return {"action": "write_code", "content": data.upper()}
+    content = data.upper()
+    return {
+        "action": "write_code",
+        "content": content,
+        "testable": _is_testable(content),
+    }
+

--- a/ai_bot/brain/thoughts/__init__.py
+++ b/ai_bot/brain/thoughts/__init__.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from datetime import datetime
+
+THOUGHTS_DIR = Path(__file__).parent
+THOUGHTS_DIR.mkdir(exist_ok=True)
+
+def log_thought(content: str, tag: str = "thought") -> None:
+    """Save a thought or decision to a markdown file."""
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    filename = f"{tag}_{timestamp}.md"
+    (THOUGHTS_DIR / filename).write_text(content)
+

--- a/ai_bot/core_config.yaml
+++ b/ai_bot/core_config.yaml
@@ -4,3 +4,6 @@ goals:
   - Collect data from the web
   - Plan actions based on the data
   - Generate or modify code
+testing_enabled: true
+log_thoughts: true
+auto_evaluate: false

--- a/ai_bot/tools/code_tester.py
+++ b/ai_bot/tools/code_tester.py
@@ -1,0 +1,36 @@
+"""Run Python unit tests on generated files."""
+
+from pathlib import Path
+import subprocess
+import sys
+import shutil
+from typing import Optional
+
+from brain.memory import update_memory
+
+
+def run_tests(target: Path) -> bool:
+    """Execute unit tests using pytest if available, otherwise unittest."""
+    if not target.exists():
+        print(f"No file found to test: {target}")
+        return False
+
+    command: Optional[list] = None
+    if shutil.which("pytest"):
+        command = ["pytest", "-q", str(target)]
+    else:
+        command = [sys.executable, "-m", "unittest", str(target)]
+
+    print(f"Running tests with: {' '.join(command)}")
+    result = subprocess.run(command, capture_output=True, text=True)
+    success = result.returncode == 0
+
+    if success:
+        print("Tests passed.")
+        update_memory({str(target): "tests_passed"})
+    else:
+        print("Tests failed.")
+        print(result.stdout)
+        print(result.stderr)
+    return success
+

--- a/ai_bot/tools/evaluate.py
+++ b/ai_bot/tools/evaluate.py
@@ -1,0 +1,11 @@
+"""Placeholder for future self-evaluation logic."""
+
+from pathlib import Path
+
+
+def evaluate_thoughts(thoughts_dir: Path) -> None:
+    """Inspect thought logs and recommend improvements (future)."""
+    print(f"Evaluating thoughts in {thoughts_dir} ...")
+    # Future implementation will parse markdown files and suggest refactors.
+
+


### PR DESCRIPTION
## Summary
- add logging helper in brain/thoughts
- implement memory update functions
- add code_tester script and evaluation placeholder
- expand planner to mark testable plans
- update bootstrap pipeline with testing and logging logic
- extend configuration with new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765ef9167c8331892d12861a767ffe