### PR TITLE
Add self-evolving planner

### DIFF
--- a/ai_bot/bootstrap.py
+++ b/ai_bot/bootstrap.py
@@ -5,6 +5,12 @@ import yaml
 
 from brain.thoughts import log_thought
 from tools.code_tester import run_tests
+from brain.recursive_planner import (
+    PROPOSAL_DIFF,
+    PROPOSAL_PY,
+    propose_self_update,
+)
+from tools.code_reviewer import review_update
 
 from inputs.web_scraper import scrape_site
 from brain.planner import plan
@@ -26,6 +32,7 @@ def main() -> None:
     log_thoughts = config.get("log_thoughts", False)
     auto_evaluate = config.get("auto_evaluate", False)
     enable_recursive_planning = config.get("enable_recursive_planning", False)
+    allow_self_rewrites = config.get("allow_self_rewrites", False)
     url = config.get("start_url", "https://example.com")
     data = scrape_site(url)
     if log_thoughts:
@@ -45,6 +52,30 @@ def main() -> None:
             run_tests(output_path)
     if auto_evaluate and log_thoughts:
         evaluate_thoughts(Path(__file__).with_name("brain").joinpath("thoughts"))
+
+    if allow_self_rewrites:
+        proposal_path = propose_self_update()
+        if proposal_path is None:
+            for p in (PROPOSAL_DIFF, PROPOSAL_PY):
+                if p.exists():
+                    proposal_path = p
+                    break
+        if proposal_path and proposal_path.exists():
+            target = None
+            content = proposal_path.read_text()
+            if proposal_path.suffix == ".diff":
+                for line in content.splitlines():
+                    if line.startswith("+++"):
+                        target = Path(line.split()[1].lstrip("b/"))
+                        break
+            else:
+                first = content.splitlines()[0] if content else ""
+                if first.startswith("# target:"):
+                    target = Path(first.split(":",1)[1].strip())
+            if target and review_update(proposal_path, target, run_tests=testing_enabled):
+                print(f"Applied self update to {target}")
+            else:
+                print("Proposed self update failed validation")
 
 
 if __name__ == "__main__":

--- a/ai_bot/brain/recursive_planner.py
+++ b/ai_bot/brain/recursive_planner.py
@@ -1,0 +1,67 @@
+"""Self-referential planning utilities for the AI bot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional
+    openai = None
+
+from ai_bot.brain.memory import MEMORY_PATH, load_memory
+from ai_bot.brain.thoughts import THOUGHTS_DIR
+from ai_bot.brain.embeddings.vector_store import STORE_PATH
+
+BASE_DIR = Path(__file__).parent
+PROPOSAL_DIFF = BASE_DIR / "proposed_update.diff"
+PROPOSAL_PY = BASE_DIR / "proposed_update.py"
+
+
+def call_llm(prompt: str) -> str:
+    """Send a prompt to OpenAI or return a placeholder string."""
+    if openai is None:
+        print("OpenAI package not available; returning placeholder response.")
+        return ""
+    resp = openai.Completion.create(engine="text-davinci-003", prompt=prompt, max_tokens=1500)
+    return resp["choices"][0]["text"]
+
+
+def summarize_thoughts(limit: int = 5) -> str:
+    files = sorted(THOUGHTS_DIR.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+    lines = []
+    for path in files:
+        text = path.read_text().splitlines()
+        first = text[0] if text else ""
+        lines.append(f"{path.name}: {first}")
+    return "\n".join(lines)
+
+
+def propose_self_update() -> Optional[Path]:
+    """Generate a diff or new module proposing self-modifications."""
+    memory = load_memory()
+    thoughts_summary = summarize_thoughts()
+    vector_info = ""
+    if STORE_PATH.exists():
+        try:
+            items = json.loads(STORE_PATH.read_text())
+            vector_info = f"Vector store size: {len(items)}"
+        except Exception:
+            vector_info = "Vector store could not be read"
+    prompt = (
+        "You are a code improving agent.\n"
+        f"Memory: {json.dumps(memory, indent=2)}\n"
+        f"Recent thoughts:\n{thoughts_summary}\n"
+        f"{vector_info}\n"
+        "Propose improvements to planner.py, code_writer.py or recursive_planner.py. "
+        "Return a unified diff or the full replacement code prefixed with '# target: <path>'."
+    )
+    result = call_llm(prompt)
+    if not result.strip():
+        return None
+    if result.lstrip().startswith("diff"):
+        PROPOSAL_DIFF.write_text(result)
+        return PROPOSAL_DIFF
+    PROPOSAL_PY.write_text(result)
+    return PROPOSAL_PY

--- a/ai_bot/core_config.yaml
+++ b/ai_bot/core_config.yaml
@@ -8,3 +8,4 @@ testing_enabled: true
 log_thoughts: true
 auto_evaluate: false
 enable_recursive_planning: false
+allow_self_rewrites: false

--- a/ai_bot/tools/code_reviewer.py
+++ b/ai_bot/tools/code_reviewer.py
@@ -1,0 +1,49 @@
+"""Validate and apply self-generated code updates."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _syntax_ok(path: Path) -> bool:
+    result = subprocess.run(["python", "-m", "py_compile", str(path)], capture_output=True, text=True)
+    if result.returncode == 0:
+        return True
+    print(result.stderr)
+    return False
+
+
+def _apply_diff(target: Path, diff_file: Path, output: Path) -> bool:
+    cmd = ["patch", str(target), "-i", str(diff_file), "-o", str(output)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr)
+        return False
+    return True
+
+
+def review_update(proposal: Path, target: Path, run_tests: bool = False) -> bool:
+    """Validate the proposed update and if valid, replace the target file."""
+    tmp_path = target.with_suffix(target.suffix + ".tmp")
+    success = False
+    try:
+        if proposal.suffix == ".diff":
+            if not _apply_diff(target, proposal, tmp_path):
+                return False
+        else:
+            shutil.copy(proposal, tmp_path)
+        if not _syntax_ok(tmp_path):
+            return False
+        if run_tests:
+            test_res = subprocess.run(["pytest", "-q"], capture_output=True, text=True)
+            if test_res.returncode != 0:
+                print(test_res.stdout)
+                print(test_res.stderr)
+                return False
+        tmp_path.replace(target)
+        success = True
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+    return success


### PR DESCRIPTION
## Summary
- integrate a recursive planner to analyse memory/thoughts and suggest code updates
- provide a `code_reviewer` tool for validating these updates
- allow self rewrites via `allow_self_rewrites` config toggle
- bootstrap now checks for proposals and applies them if valid

## Testing
- `python -m py_compile ai_bot/brain/recursive_planner.py`
- `python -m py_compile ai_bot/tools/code_reviewer.py`
- `python -m py_compile ai_bot/bootstrap.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687668eef7ec8331bbd3e1426f504901