### PR TITLE
Add simple plugin loader with example plugin

### DIFF
--- a/ai_bot/plugins/example_plugin.py
+++ b/ai_bot/plugins/example_plugin.py
@@ -1,0 +1,5 @@
+"""Example plugin used for testing the plugin loader."""
+
+def fetch(config=None):
+    """Return a static message."""
+    return {"message": "Hello from plugin!"}


### PR DESCRIPTION
## Summary
- implement `load_plugins()` function to dynamically import all `.py` files in `ai_bot/plugins`
- simplify `PluginManager` to rely on `load_plugins`
- include new sample `example_plugin` with a basic `fetch()`

## Testing
- `python -m py_compile ai_bot/brain/plugin_manager.py ai_bot/plugins/example_plugin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792843d78c8331a960b935d6fdd2e8