### PR TITLE
Add beta signup emails and neon animations

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -6,6 +6,8 @@
   <title>About - Ninvax</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
 </head>
 <body>
   <nav>
@@ -14,13 +16,14 @@
     <a href="contact.html">Contact</a>
     <a href="signup.html">Beta Signup</a>
   </nav>
-  <div class="container">
+  <div class="container fade-slide-up">
     <h1 class="glitch">About Ninvax</h1>
-    <p>Ninvax shifts perspectives and builds towards a trillion-dollar empire, hacking reality from Saturn's orbit to the cosmos 🪐.</p>
+    <p class="about-text">Ninvax shifts perspectives and builds towards a trillion-dollar empire, hacking reality from Saturn's orbit to the cosmos 🪐.</p>
     <div class="saturn-ring-animation" style="display:none;"></div>
   </div>
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <script src="assets/js/animations.js"></script>
 </body>
 </html>

--- a/site/assets/css/cyberpunk.css
+++ b/site/assets/css/cyberpunk.css
@@ -23,7 +23,9 @@ nav a {
 }
 
 nav a:hover {
+    color: #ff007a;
     text-shadow: 0 0 5px #ff00ff, 0 0 10px #ff007a;
+    animation: glitch-hover 0.2s alternate 2;
 }
 
 .hero {
@@ -35,7 +37,7 @@ nav a:hover {
     font-size: 3em;
     color: #ff00ff;
     margin: 0 0 20px;
-    animation: glitch 1s linear infinite;
+    animation: glitch 1s linear infinite, neon-flicker 4s linear infinite;
 }
 
 .hero p {
@@ -51,12 +53,14 @@ nav a:hover {
     margin-top: 20px;
     text-decoration: none;
     box-shadow: 0 0 10px #ff00ff;
-    transition: box-shadow 0.3s, background 0.3s;
+    transition: box-shadow 0.3s, background 0.3s, transform 0.2s;
 }
 
 .neon-button:hover {
     background: #ff007a;
     box-shadow: 0 0 20px #ff007a;
+    transform: scale(1.05);
+    animation: glitch-hover 0.2s alternate 2;
 }
 
 .container {
@@ -73,6 +77,10 @@ input, textarea {
     background: #1a1a1a;
     border: 2px solid #ff00ff;
     color: #fff;
+}
+input:focus, textarea:focus {
+    outline: none;
+    box-shadow: 0 0 10px #ff007a;
 }
 
 footer {
@@ -104,3 +112,45 @@ footer {
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* Fade in and slide up */
+@keyframes fade-slide-up {
+    from { opacity: 0; transform: translateY(30px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Button glitch hover */
+@keyframes glitch-hover {
+    0%, 100% { transform: translateX(0); }
+    50% { transform: translateX(-2px); }
+}
+
+/* Neon pulsing ring */
+@keyframes neon-pulse {
+    0%, 100% { box-shadow: 0 0 10px #ff00ff; }
+    50% { box-shadow: 0 0 20px #ff007a; }
+}
+
+@keyframes neon-flicker {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+}
+
+.fade-slide-up {
+    animation: fade-slide-up 1s ease both;
+}
+
+
+.saturn-ring-animation {
+    animation: spin 3s linear infinite, neon-pulse 2s ease-in-out infinite;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    pointer-events: none;
+    background-image: repeating-linear-gradient(0deg,rgba(255,255,255,0.03) 0, rgba(255,255,255,0.03) 2px, transparent 2px, transparent 4px);
+    mix-blend-mode: overlay;
+    z-index: 1;
+}

--- a/site/assets/js/animations.js
+++ b/site/assets/js/animations.js
@@ -1,0 +1,26 @@
+// Global GSAP animations
+window.addEventListener('load', () => {
+  if (document.querySelector('.hero')) {
+    const tl = gsap.timeline();
+    tl.from('.hero img', {y: 50, opacity: 0, duration: 1})
+      .from('.hero h1', {y: 50, opacity: 0, duration: 1}, '-=0.5')
+      .from('.hero .neon-button', {opacity: 0, duration: 0.5}, '-=0.3');
+  }
+
+  if (document.getElementById('beta-signup')) {
+    gsap.from('#beta-signup', {y: 100, opacity: 0, duration: 1});
+    document.querySelectorAll('#beta-signup input').forEach(input => {
+      input.addEventListener('focus', () => gsap.to(input, {scale: 1.05, boxShadow: '0 0 15px #ff007a'}));
+      input.addEventListener('blur', () => gsap.to(input, {scale: 1, boxShadow: '0 0 0 #000'}));
+    });
+  }
+
+  if (document.querySelector('.about-text')) {
+    gsap.from('.about-text', {
+      scrollTrigger: '.about-text',
+      y: 50,
+      opacity: 0,
+      duration: 1
+    });
+  }
+});

--- a/site/assets/js/cyberpunk.js
+++ b/site/assets/js/cyberpunk.js
@@ -17,7 +17,24 @@ function handleContact(event, endpoint) {
 }
 
 function handleSignup(event) {
-  handleContact(event, '/signup');
-  const ring = document.querySelector('.saturn-ring-animation');
-  if (ring) ring.style.display = 'block';
+  event.preventDefault();
+  const form = event.target;
+  const data = Object.fromEntries(new FormData(form).entries());
+  fetch('/.netlify/functions/send-email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+  .then(res => res.ok ? res.text() : Promise.reject('Error'))
+  .then(() => {
+    form.reset();
+    const confirm = document.getElementById('confirmation');
+    if (confirm) {
+      confirm.style.display = 'block';
+      gsap.fromTo('#confirmation', {opacity:0}, {opacity:1,duration:0.6});
+      const ring = confirm.querySelector('.saturn-ring-animation');
+      if (ring) ring.style.display = 'block';
+    }
+  })
+  .catch(err => console.error(err));
 }

--- a/site/contact.html
+++ b/site/contact.html
@@ -6,6 +6,7 @@
   <title>Contact - Ninvax</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
 </head>
 <body>
   <nav>
@@ -28,6 +29,7 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <script src="assets/js/animations.js"></script>
   <script src="assets/js/cyberpunk.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -6,6 +6,8 @@
   <title>Ninvax</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
 </head>
 <body>
   <nav>
@@ -14,7 +16,7 @@
     <a href="contact.html">Contact</a>
     <a href="signup.html">Beta Signup</a>
   </nav>
-  <div class="hero">
+  <div class="hero fade-slide-up">
     <img src="images/logo.svg" alt="Ninvax logo" style="width:200px;">
     <h1 class="glitch">Reframe Your Reality from Saturn to the Stars 🪐</h1>
     <a class="neon-button" href="signup.html">Join the Beta</a>
@@ -22,5 +24,6 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <script src="assets/js/animations.js"></script>
 </body>
 </html>

--- a/site/netlify/functions/send-email.js
+++ b/site/netlify/functions/send-email.js
@@ -1,0 +1,38 @@
+const nodemailer = require('nodemailer');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+  let data;
+  try {
+    data = JSON.parse(event.body);
+  } catch (err) {
+    return { statusCode: 400, body: 'Invalid JSON' };
+  }
+  const { name, email } = data;
+  if (!name || !email) {
+    return { statusCode: 400, body: 'Missing fields' };
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: process.env.EMAIL_SERVICE,
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  });
+
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL_USER,
+      to: 'ninvax@icloud.com',
+      subject: 'New Beta Signup',
+      text: `Name: ${name}\nEmail: ${email}`,
+    });
+    return { statusCode: 200, body: 'Success' };
+  } catch (err) {
+    console.error(err);
+    return { statusCode: 500, body: 'Error sending email' };
+  }
+};

--- a/site/signup.html
+++ b/site/signup.html
@@ -6,6 +6,8 @@
   <title>Ninvax Beta Signup 🪐</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
 </head>
 <body>
   <nav>
@@ -14,7 +16,7 @@
     <a href="contact.html">Contact</a>
     <a href="signup.html" class="active">Beta Signup</a>
   </nav>
-  <div class="container">
+  <div class="container fade-slide-up">
     <h1 class="glitch">Ninvax Beta 🪐</h1>
     <p class="tagline">Join the revolution. Reframe your reality.</p>
     <form id="beta-signup" onsubmit="handleSignup(event)">
@@ -32,5 +34,6 @@
     <p>Ninvax 🪐 2025</p>
   </footer>
   <script src="assets/js/cyberpunk.js"></script>
+  <script src="assets/js/animations.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Netlify function `send-email.js` for beta signup emails
- enhance cyberpunk CSS animations and effects
- update signup form JS to use serverless email
- create GSAP animation script and load it on main pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5f97a488331bb868f08a3c26a71