### PR TITLE
Enhance site footer with OpenAI link

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -24,6 +24,12 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <div class="openai-credit">
+    <a href="https://openai.com" target="_blank" rel="noopener">
+      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    </a>
+    <span class="chatgpt-badge">Made with ChatGPT</span>
+  </div>
   <script src="assets/js/animations.js"></script>
 </body>
 </html>

--- a/site/assets/css/cyberpunk.css
+++ b/site/assets/css/cyberpunk.css
@@ -154,3 +154,31 @@ body::before {
     mix-blend-mode: overlay;
     z-index: 1;
 }
+
+/* ChatGPT credit */
+.openai-credit {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin: 2em 0;
+}
+
+.openai-logo {
+    width: 32px;
+    height: 32px;
+    animation: spin 6s linear infinite;
+}
+
+.chatgpt-badge {
+    background: #fff;
+    color: #000;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font-size: 0.9em;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -3320,10 +3320,38 @@ input, select, textarea {
 		padding: 0 2.5em;
 	}
 
-		@media screen and (max-width: 736px) {
+@media screen and (max-width: 736px) {
 
-			#wrapper > * > .inner {
-				padding: 0 1.25em;
-			}
+        #wrapper > * > .inner {
+                padding: 0 1.25em;
+        }
 
-		}
+}
+
+/* ChatGPT credit */
+.openai-credit {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin: 2em 0;
+}
+
+.openai-logo {
+    width: 32px;
+    height: 32px;
+    animation: spin 6s linear infinite;
+}
+
+.chatgpt-badge {
+    background: #fff;
+    color: #000;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font-size: 0.9em;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/site/blog.html
+++ b/site/blog.html
@@ -108,6 +108,12 @@
                             </ul>
                         </div>
                     </footer>
+                    <div class="openai-credit">
+                        <a href="https://openai.com" target="_blank" rel="noopener">
+                            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                        </a>
+                        <span class="chatgpt-badge">Made with ChatGPT</span>
+                    </div>
 
             </div>
 

--- a/site/contact.html
+++ b/site/contact.html
@@ -29,6 +29,12 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <div class="openai-credit">
+    <a href="https://openai.com" target="_blank" rel="noopener">
+      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    </a>
+    <span class="chatgpt-badge">Made with ChatGPT</span>
+  </div>
   <script src="assets/js/animations.js"></script>
   <script src="assets/js/cyberpunk.js"></script>
 </body>

--- a/site/gallery.html
+++ b/site/gallery.html
@@ -107,7 +107,13 @@
                                                                <li>&copy; Ninvax. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 						</div>
-					</footer>
+                                        </footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/images/openai-logo.svg
+++ b/site/images/openai-logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="#000" stroke-width="5">
+    <circle cx="50" cy="50" r="20"/>
+    <path d="M50 5a45 45 0 0 1 0 90"/>
+    <path d="M5 50a45 45 0 0 1 90 0"/>
+  </g>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -21,6 +21,11 @@
             padding: 10px;
             text-align: center;
             border-bottom: 2px solid #800080;
+            animation: pulse 3s infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { box-shadow: 0 0 5px #800080; }
+            50% { box-shadow: 0 0 15px #ff00ff; }
         }
         .search-bar {
             padding: 10px;
@@ -76,6 +81,30 @@
             text-align: center;
             padding: 10px;
             color: #800080;
+        }
+        .openai-credit {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 10px;
+            margin: 20px 0;
+        }
+        .openai-logo {
+            width: 32px;
+            height: 32px;
+            vertical-align: middle;
+            animation: spin 6s linear infinite;
+        }
+        .chatgpt-badge {
+            background: #fff;
+            color: #000;
+            padding: 4px 8px;
+            border-radius: 6px;
+            font-size: 0.9em;
+        }
+        @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
         }
     </style>
 </head>
@@ -166,5 +195,11 @@
         };
     </script>
     <footer>© 2025 Ninvax</footer>
+    <div class="openai-credit">
+        <a href="https://openai.com" target="_blank" rel="noopener">
+            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+        </a>
+        <span class="chatgpt-badge">Made with ChatGPT</span>
+    </div>
 </body>
 </html>

--- a/site/projects.html
+++ b/site/projects.html
@@ -92,7 +92,13 @@
                                                                <li>&copy; Ninvax. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 						</div>
-					</footer>
+                                        </footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/barcode-catalog.html
+++ b/site/projects/barcode-catalog.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/crypto-trading-bot.html
+++ b/site/projects/crypto-trading-bot.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/cyberpatriot.html
+++ b/site/projects/cyberpatriot.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/google-cybersecurity.html
+++ b/site/projects/google-cybersecurity.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/hackathons.html
+++ b/site/projects/hackathons.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/independent-study.html
+++ b/site/projects/independent-study.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/mlh-nsa-team.html
+++ b/site/projects/mlh-nsa-team.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/open-to-work.html
+++ b/site/projects/open-to-work.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/quantum-curious.html
+++ b/site/projects/quantum-curious.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/store-associate.html
+++ b/site/projects/store-associate.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/projects/us-navy-veteran.html
+++ b/site/projects/us-navy-veteran.html
@@ -95,6 +95,12 @@
 							</ul>
 						</div>
 					</footer>
+                                        <div class="openai-credit">
+                                            <a href="https://openai.com" target="_blank" rel="noopener">
+                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                            </a>
+                                            <span class="chatgpt-badge">Made with ChatGPT</span>
+                                        </div>
 
 			</div>
 

--- a/site/resume.html
+++ b/site/resume.html
@@ -215,7 +215,13 @@
                                                                <li>&copy; Ninvax. All rights reserved</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 						</div>
-					</footer>
+                                    </footer>
+                                    <div class="openai-credit">
+                                        <a href="https://openai.com" target="_blank" rel="noopener">
+                                            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+                                        </a>
+                                        <span class="chatgpt-badge">Made with ChatGPT</span>
+                                    </div>
 
 			</div>
 

--- a/site/signup.html
+++ b/site/signup.html
@@ -33,6 +33,12 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
+  <div class="openai-credit">
+    <a href="https://openai.com" target="_blank" rel="noopener">
+      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    </a>
+    <span class="chatgpt-badge">Made with ChatGPT</span>
+  </div>
   <script src="assets/js/cyberpunk.js"></script>
   <script src="assets/js/animations.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- credit OpenAI on all site pages with a spinning logo and "Made with ChatGPT" badge
- add simple pulse animation to the home page header
- add shared styles for the credit badge in `main.css` and `cyberpunk.css`
- include placeholder OpenAI logo asset

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` in frontend *(fails: 403 Forbidden)*
- `npm install` in backend *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68840df7094083319f193c45ae5618f9