### PR TITLE
Add basic scheduler test and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+name: Run Python and Node tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run Python tests
+        run: pytest ai_bot/tests
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        run: |
+          if [ -f frontend/package.json ]; then
+            cd frontend && npm ci
+          fi
+
+      - name: Run frontend tests
+        run: |
+          if [ -f frontend/package.json ] && grep -q "\"test\"" frontend/package.json; then
+            cd frontend && npm test
+          else
+            echo "No frontend tests defined"
+          fi
+
+      - name: Install backend dependencies
+        run: |
+          if [ -f backend/package.json ]; then
+            cd backend && npm ci
+          fi
+
+      - name: Run backend tests
+        run: |
+          if [ -f backend/package.json ] && grep -q "\"test\"" backend/package.json; then
+            cd backend && npm test
+          else
+            echo "No backend tests defined"
+          fi

--- a/ai_bot/tests/test_scheduler.py
+++ b/ai_bot/tests/test_scheduler.py
@@ -1,0 +1,19 @@
+import ai_bot.brain.scheduler as scheduler
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+
+def test_scheduler_due():
+    base = datetime(2024, 1, 1, 0, 0, 0)
+    with patch.object(scheduler, "datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = base
+        sched = scheduler.Scheduler({"job": {"interval": 60}})
+
+        mock_datetime.utcnow.return_value = base
+        assert sched.due() == ["job"]
+
+        mock_datetime.utcnow.return_value = base + timedelta(seconds=30)
+        assert sched.due() == []
+
+        mock_datetime.utcnow.return_value = base + timedelta(seconds=60)
+        assert sched.due() == ["job"]


### PR DESCRIPTION
## Summary
- add unit test for `Scheduler`
- run tests under `ai_bot/tests`
- create GitHub Actions workflow to run Python and Node tests

## Testing
- `pytest ai_bot/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688410edef4883319f3fd2d08a29b4b3