### PR TITLE
Add simple login and admin controls

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -15,6 +15,9 @@
     <a href="about.html">About</a>
     <a href="contact.html">Contact</a>
     <a href="signup.html">Beta Signup</a>
+    <a href="login.html" id="loginLink">Login</a>
+    <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+    <a href="#" id="logoutLink" style="display:none;">Logout</a>
   </nav>
   <div class="container fade-slide-up">
     <h1 class="glitch">About Ninvax</h1>
@@ -31,5 +34,6 @@
     <span class="chatgpt-badge">Made with ChatGPT</span>
   </div>
   <script src="assets/js/animations.js"></script>
+  <script src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/site/admin.html
+++ b/site/admin.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin - Ninvax</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="login.html" id="loginLink">Login</a>
+    <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+    <a href="#" id="logoutLink" style="display:none;">Logout</a>
+  </nav>
+  <h1 style="text-align:center; margin-top:40px;">Admin Controls</h1>
+  <p style="text-align:center;">Only visible to admins.</p>
+
+  <script src="assets/js/auth.js"></script>
+  <script>
+    if (localStorage.getItem('isAdmin') !== 'true') {
+      window.location.href = 'login.html';
+    }
+  </script>
+</body>
+</html>

--- a/site/assets/js/auth.js
+++ b/site/assets/js/auth.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginLink = document.getElementById('loginLink');
+  const adminLink = document.getElementById('adminLink');
+  const logoutLink = document.getElementById('logoutLink');
+
+  function updateLinks() {
+    const isAdmin = localStorage.getItem('isAdmin') === 'true';
+    if (isAdmin) {
+      if (adminLink) adminLink.style.display = 'inline';
+      if (logoutLink) logoutLink.style.display = 'inline';
+      if (loginLink) loginLink.style.display = 'none';
+    } else {
+      if (adminLink) adminLink.style.display = 'none';
+      if (logoutLink) logoutLink.style.display = 'none';
+      if (loginLink) loginLink.style.display = 'inline';
+    }
+  }
+
+  if (logoutLink) {
+    logoutLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('isAdmin');
+      updateLinks();
+    });
+  }
+
+  updateLinks();
+});

--- a/site/blog.html
+++ b/site/blog.html
@@ -40,6 +40,9 @@
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="resume.html">Resume</a></li>
+                            <li><a href="login.html" id="loginLink">Login</a></li>
+                            <li><a href="admin.html" id="adminLink" style="display:none;">Admin</a></li>
+                            <li><a href="#" id="logoutLink" style="display:none;">Logout</a></li>
                         </ul>
                     </nav>
 
@@ -123,6 +126,7 @@
             <script src="assets/js/breakpoints.min.js"></script>
             <script src="assets/js/util.js"></script>
             <script src="assets/js/main.js"></script>
+            <script src="assets/js/auth.js"></script>
 
     </body>
 </html>

--- a/site/contact.html
+++ b/site/contact.html
@@ -14,6 +14,9 @@
     <a href="about.html">About</a>
     <a href="contact.html">Contact</a>
     <a href="signup.html">Beta Signup</a>
+    <a href="login.html" id="loginLink">Login</a>
+    <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+    <a href="#" id="logoutLink" style="display:none;">Logout</a>
   </nav>
   <div class="container">
     <div class="saturn-ring-animation" style="display:block;"></div>
@@ -37,5 +40,6 @@
   </div>
   <script src="assets/js/animations.js"></script>
   <script src="assets/js/cyberpunk.js"></script>
+  <script src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/site/gallery.html
+++ b/site/gallery.html
@@ -40,6 +40,9 @@
                             <li><a href="gallery.html">Gallery</a></li>
                             <li><a href="blog.html">Blog</a></li>
                             <li><a href="resume.html">Resume</a></li>
+                            <li><a href="login.html" id="loginLink">Login</a></li>
+                            <li><a href="admin.html" id="adminLink" style="display:none;">Admin</a></li>
+                            <li><a href="#" id="logoutLink" style="display:none;">Logout</a></li>
                         </ul>
                     </nav>
 
@@ -121,8 +124,9 @@
 			<script src="assets/js/jquery.min.js"></script>
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+                        <script src="assets/js/util.js"></script>
+                        <script src="assets/js/main.js"></script>
+                        <script src="assets/js/auth.js"></script>
 
-	</body>
+        </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -23,6 +23,14 @@
             border-bottom: 2px solid #800080;
             animation: pulse 3s infinite;
         }
+        .nav {
+            margin-top: 10px;
+        }
+        .nav a {
+            color: #FF00FF;
+            margin: 0 10px;
+            text-decoration: none;
+        }
         @keyframes pulse {
             0%, 100% { box-shadow: 0 0 5px #800080; }
             50% { box-shadow: 0 0 15px #ff00ff; }
@@ -111,6 +119,12 @@
 <body>
     <div class="header">
         <h1>Ninvax Marketplace</h1>
+        <nav class="nav">
+            <a href="index.html">Home</a>
+            <a href="login.html" id="loginLink">Login</a>
+            <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+            <a href="#" id="logoutLink" style="display:none;">Logout</a>
+        </nav>
     </div>
     <main>
         <input type="text" class="search-bar" placeholder="Search strains..." id="searchInput" onkeyup="filterStrains()">
@@ -194,6 +208,7 @@
             setInterval(loadStrains, 24 * 60 * 60 * 1000);
         };
     </script>
+    <script src="assets/js/auth.js"></script>
     <footer>© 2025 Ninvax</footer>
     <div class="openai-credit">
         <a href="https://openai.com" target="_blank" rel="noopener">

--- a/site/login.html
+++ b/site/login.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - Ninvax</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <style>
+    form {
+      max-width: 300px;
+      margin: 40px auto;
+      text-align: center;
+    }
+    input {
+      width: 100%;
+      margin: 10px 0;
+      padding: 10px;
+    }
+    button {
+      padding: 10px 20px;
+    }
+    #error {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="login.html" id="loginLink">Login</a>
+    <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+    <a href="#" id="logoutLink" style="display:none;">Logout</a>
+  </nav>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" required>
+    <input type="password" id="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+    <div id="error"></div>
+  </form>
+
+  <script src="assets/js/auth.js"></script>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const u = document.getElementById('username').value.trim();
+      const p = document.getElementById('password').value;
+      if (u === 'ninvax' && p === 'ninvaxxx') {
+        localStorage.setItem('isAdmin', 'true');
+        window.location.href = 'index.html';
+      } else {
+        document.getElementById('error').textContent = 'Invalid credentials';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/site/projects.html
+++ b/site/projects.html
@@ -38,8 +38,11 @@
                             <li><a href="index.html">Home</a></li>
                             <li><a href="projects.html">Projects</a></li>
                             <li><a href="gallery.html">Gallery</a></li>
-                            <li><a href="blog.html">Blog</a></li>
-                            <li><a href="resume.html">Resume</a></li>
+                           <li><a href="blog.html">Blog</a></li>
+                           <li><a href="resume.html">Resume</a></li>
+                           <li><a href="login.html" id="loginLink">Login</a></li>
+                           <li><a href="admin.html" id="adminLink" style="display:none;">Admin</a></li>
+                           <li><a href="#" id="logoutLink" style="display:none;">Logout</a></li>
                         </ul>
                     </nav>
 
@@ -106,8 +109,9 @@
 			<script src="assets/js/jquery.min.js"></script>
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+                       <script src="assets/js/util.js"></script>
+                       <script src="assets/js/main.js"></script>
+                        <script src="assets/js/auth.js"></script>
 
-	</body>
+        </body>
 </html>

--- a/site/resume.html
+++ b/site/resume.html
@@ -38,10 +38,13 @@
                                                         <li><a href="index.html">Home</a></li>
                                                         <li><a href="projects.html">Projects</a></li>
                                                         <li><a href="gallery.html">Gallery</a></li>
-                                                        <li><a href="blog.html">Blog</a></li>
-                                                        <li><a href="resume.html">Resume</a></li>
-                                                </ul>
-                                        </nav>
+                                                       <li><a href="blog.html">Blog</a></li>
+                                                       <li><a href="resume.html">Resume</a></li>
+                                                       <li><a href="login.html" id="loginLink">Login</a></li>
+                                                       <li><a href="admin.html" id="adminLink" style="display:none;">Admin</a></li>
+                                                       <li><a href="#" id="logoutLink" style="display:none;">Logout</a></li>
+                                               </ul>
+                                       </nav>
 
 				<!-- Main -->
 					<div id="main">
@@ -229,8 +232,9 @@
 			<script src="assets/js/jquery.min.js"></script>
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+                       <script src="assets/js/util.js"></script>
+                       <script src="assets/js/main.js"></script>
+                        <script src="assets/js/auth.js"></script>
 
-	</body>
+        </body>
 </html>

--- a/site/signup.html
+++ b/site/signup.html
@@ -15,6 +15,9 @@
     <a href="about.html">About</a>
     <a href="contact.html">Contact</a>
     <a href="signup.html" class="active">Beta Signup</a>
+    <a href="login.html" id="loginLink">Login</a>
+    <a href="admin.html" id="adminLink" style="display:none;">Admin</a>
+    <a href="#" id="logoutLink" style="display:none;">Logout</a>
   </nav>
   <div class="container fade-slide-up">
     <h1 class="glitch">Ninvax Beta 🪐</h1>
@@ -41,5 +44,6 @@
   </div>
   <script src="assets/js/cyberpunk.js"></script>
   <script src="assets/js/animations.js"></script>
+  <script src="assets/js/auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add auth.js for basic localStorage login handling
- add login and admin pages
- inject navigation links across site pages
- show admin link and logout when logged in

## Testing
- `node site/assets/js/server.js` *(manual server start)*

------
https://chatgpt.com/codex/tasks/task_e_688418a4ebf08331a393fba0ae70fc2c