### PR TITLE
Add price validation with toasts

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -213,7 +213,7 @@
         }
 
         document.getElementById('price').addEventListener('input', function() {
-            this.value = this.value.replace(/[^0-9.]/g, '');
+            this.value = this.value.match(/^\d*\.?\d*$/) ? this.value : this.value.slice(0, -1);
         });
 
         document.getElementById('storeForm').addEventListener('submit', function(e) {

--- a/site/index.html
+++ b/site/index.html
@@ -85,6 +85,23 @@
             border-radius: 5px;
             cursor: pointer;
         }
+        .error {
+            color: red;
+            font-size: 0.9em;
+            margin-top: 4px;
+        }
+        .toast {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            background: #4caf50;
+            color: #fff;
+            padding: 10px 20px;
+            border-radius: 5px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.5s ease;
+        }
         footer {
             text-align: center;
             padding: 10px;
@@ -133,6 +150,7 @@
         <form id="storeForm" class="store-form">
             <input type="text" id="name" placeholder="Strain name" required>
             <input type="number" id="price" placeholder="Price" step="0.01" required>
+            <div id="priceError" class="error"></div>
             <input type="text" id="store" placeholder="Store name" required>
             <button type="submit" class="submit-btn">Add Strain</button>
         </form>
@@ -184,12 +202,35 @@
             renderStrains(filtered);
         }
 
+        function showToast(msg, isError = false) {
+            const toast = document.getElementById('toast');
+            toast.textContent = msg;
+            toast.style.background = isError ? '#d33' : '#4caf50';
+            toast.style.opacity = '1';
+            setTimeout(() => {
+                toast.style.opacity = '0';
+            }, 2000);
+        }
+
+        document.getElementById('price').addEventListener('input', function() {
+            this.value = this.value.replace(/[^0-9.]/g, '');
+        });
+
         document.getElementById('storeForm').addEventListener('submit', function(e) {
             e.preventDefault();
             const name = document.getElementById('name').value.trim();
-            const price = parseFloat(document.getElementById('price').value);
+            const priceInput = document.getElementById('price');
+            const price = parseFloat(priceInput.value);
             const store = document.getElementById('store').value.trim();
-            if (!name || !store || isNaN(price)) return;
+            const priceError = document.getElementById('priceError');
+            if (!name || !store || isNaN(price) || price <= 0) {
+                if (isNaN(price) || price <= 0) {
+                    priceError.textContent = 'Price must be > 0';
+                }
+                showToast('Failed to add strain', true);
+                return;
+            }
+            priceError.textContent = '';
             const existing = strains.find(s => s.name.toLowerCase() === name.toLowerCase());
             if (existing) {
                 existing.price = price;
@@ -201,6 +242,7 @@
             localStorage.setItem('strainsData', JSON.stringify(strains));
             localStorage.setItem('strainsTimestamp', Date.now().toString());
             renderStrains();
+            showToast('Strain added!');
         });
 
         window.onload = function() {
@@ -216,5 +258,6 @@
         </a>
         <span class="chatgpt-badge">Made with ChatGPT</span>
     </div>
+    <div id="toast" class="toast"></div>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -227,8 +227,9 @@
             const price = parseFloat(priceInput.value);
             const store = document.getElementById('store').value.trim();
             const priceError = document.getElementById('priceError');
-            if (!name || !store || isNaN(price) || price <= 0) {
-                if (isNaN(price) || price <= 0) {
+            const isInvalidPrice = isNaN(price) || price <= 0;
+            if (!name || !store || isInvalidPrice) {
+                if (isInvalidPrice) {
                     priceError.textContent = 'Price must be > 0';
                 }
                 showToast('Failed to add strain', true);

--- a/site/index.html
+++ b/site/index.html
@@ -204,6 +204,10 @@
 
         function showToast(msg, isError = false) {
             const toast = document.getElementById('toast');
+            if (!toast) {
+                console.error('Toast element not found in the DOM.');
+                return;
+            }
             toast.textContent = msg;
             toast.style.background = isError ? '#d33' : '#4caf50';
             toast.style.opacity = '1';


### PR DESCRIPTION
## Summary
- add error and toast styles
- show inline validation and toast on add strain
- prevent non-numeric price input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68841bae263c8331b73e99c1fd311a86