### PR TITLE
Improve a11y across static site and frontend

### DIFF
--- a/frontend/components/ProjectCard.js
+++ b/frontend/components/ProjectCard.js
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export default function ProjectCard({ title, description, image, codeLink, projectLink }) {
   return (
-    <div style={{ border: '1px solid #ddd', borderRadius: '8px', overflow: 'hidden', width: '300px', margin: '1rem' }}>
+    <div tabIndex={0} style={{ border: '1px solid #ddd', borderRadius: '8px', overflow: 'hidden', width: '300px', margin: '1rem' }}>
       {image && (
         <div style={{ position: 'relative', height: '180px' }}>
           <Image src={image} alt={title} fill style={{ objectFit: 'cover' }} />

--- a/frontend/pages/contact.js
+++ b/frontend/pages/contact.js
@@ -32,9 +32,12 @@ export default function Contact() {
       <main style={{ padding: '2rem' }}>
         <h1>Contact</h1>
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', maxWidth: '400px' }}>
-          <input type="text" name="name" placeholder="Name" required style={{ marginBottom: '0.5rem' }} />
-          <input type="email" name="email" placeholder="Email" required style={{ marginBottom: '0.5rem' }} />
-          <textarea name="message" placeholder="Message" required style={{ marginBottom: '0.5rem' }} />
+          <label htmlFor="name">Name</label>
+          <input id="name" type="text" name="name" placeholder="Name" aria-label="Name" required style={{ marginBottom: '0.5rem' }} />
+          <label htmlFor="email">Email</label>
+          <input id="email" type="email" name="email" placeholder="Email" aria-label="Email" required style={{ marginBottom: '0.5rem' }} />
+          <label htmlFor="message">Message</label>
+          <textarea id="message" name="message" placeholder="Message" aria-label="Message" required style={{ marginBottom: '0.5rem' }} />
           <button type="submit">Send</button>
         </form>
         {status && <p>{status}</p>}

--- a/site/assets/css/cyberpunk.css
+++ b/site/assets/css/cyberpunk.css
@@ -27,6 +27,14 @@ nav a:hover {
     text-shadow: 0 0 5px #ff00ff, 0 0 10px #ff007a;
     animation: glitch-hover 0.2s alternate 2;
 }
+nav a:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+button:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
 
 .hero {
     text-align: center;
@@ -61,6 +69,10 @@ nav a:hover {
     box-shadow: 0 0 20px #ff007a;
     transform: scale(1.05);
     animation: glitch-hover 0.2s alternate 2;
+}
+.neon-button:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
 }
 
 .container {

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -98,9 +98,14 @@ input, select, textarea {
 		box-sizing: inherit;
 	}
 
-	body {
-		background: #ffffff;
-	}
+body {
+        background: #ffffff;
+}
+a:focus,
+button:focus {
+        outline: 2px solid #000;
+        outline-offset: 2px;
+}
 
 		body.is-preload *, body.is-preload *:before, body.is-preload *:after {
 			-moz-animation: none !important;

--- a/site/contact.html
+++ b/site/contact.html
@@ -22,9 +22,18 @@
     <div class="saturn-ring-animation" style="display:block;"></div>
     <h1 class="glitch">Contact Us</h1>
     <form onsubmit="handleContact(event, '/contact')">
-      <input type="text" name="name" placeholder="Name" required>
-      <input type="email" name="email" placeholder="Email" required>
-      <textarea name="message" placeholder="Message" required></textarea>
+      <label>
+        Name
+        <input type="text" name="name" placeholder="Name" aria-label="Name" required>
+      </label>
+      <label>
+        Email
+        <input type="email" name="email" placeholder="Email" aria-label="Email" required>
+      </label>
+      <label>
+        Message
+        <textarea name="message" placeholder="Message" aria-label="Message" required></textarea>
+      </label>
       <button type="submit" class="neon-button">Send</button>
     </form>
     <div id="confirmation" style="display:none;">Thanks for reaching out!</div>

--- a/site/gallery.html
+++ b/site/gallery.html
@@ -75,20 +75,26 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="/contact">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
+                                                                <form method="post" action="/contact">
+                                                                        <div class="fields">
+                                                                               <div class="field half">
+                                                                               <label>Name
+                                                                               <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" />
+                                                                               </label>
+                                                                               </div>
+                                                                               <div class="field half">
+                                                                               <label>Email
+                                                                               <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" />
+                                                                               </label>
+                                                                               </div>
+                                                                               <div class="field">
+                                                                               <label>Message
+                                                                               <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea>
+                                                                               </label>
+                                                                               </div>
+                                                                        </div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,10 @@
             color: #FF00FF;
             margin: 0 10px;
             text-decoration: none;
+            outline-offset: 2px;
+        }
+        .nav a:focus {
+            outline: 2px solid #fff;
         }
         @keyframes pulse {
             0%, 100% { box-shadow: 0 0 5px #800080; }
@@ -54,6 +58,10 @@
             padding: 10px;
             margin: 10px 0;
             color: #FFFFFF;
+            outline-offset: 2px;
+        }
+        .strain-card:focus {
+            outline: 2px solid #ff00ff;
         }
         .order-btn {
             background-color: #FF00FF;
@@ -62,6 +70,10 @@
             border: none;
             border-radius: 5px;
             cursor: pointer;
+            outline-offset: 2px;
+        }
+        .order-btn:focus {
+            outline: 2px solid #fff;
         }
         .store-form {
             padding: 10px;
@@ -84,6 +96,10 @@
             border: none;
             border-radius: 5px;
             cursor: pointer;
+            outline-offset: 2px;
+        }
+        .submit-btn:focus {
+            outline: 2px solid #fff;
         }
         footer {
             text-align: center;
@@ -127,13 +143,22 @@
         </nav>
     </div>
     <main>
-        <input type="text" class="search-bar" placeholder="Search strains..." id="searchInput" onkeyup="filterStrains()">
+        <input type="text" class="search-bar" placeholder="Search strains..." aria-label="Search strains" id="searchInput" onkeyup="filterStrains()">
         <div class="strain-list" id="strainList"></div>
 
         <form id="storeForm" class="store-form">
-            <input type="text" id="name" placeholder="Strain name" required>
-            <input type="number" id="price" placeholder="Price" step="0.01" required>
-            <input type="text" id="store" placeholder="Store name" required>
+            <label>
+                Strain name
+                <input type="text" id="name" placeholder="Strain name" aria-label="Strain name" required>
+            </label>
+            <label>
+                Price
+                <input type="number" id="price" placeholder="Price" step="0.01" aria-label="Price" required>
+            </label>
+            <label>
+                Store name
+                <input type="text" id="store" placeholder="Store name" aria-label="Store name" required>
+            </label>
             <button type="submit" class="submit-btn">Add Strain</button>
         </form>
     </main>
@@ -173,6 +198,7 @@
             data.forEach((strain) => {
                 const card = document.createElement('div');
                 card.className = 'strain-card';
+                card.tabIndex = 0;
                 card.innerHTML = `<h3>${strain.name}</h3><p>$${strain.price.toFixed(2)} at ${strain.store}</p>`;
                 list.appendChild(card);
             });

--- a/site/login.html
+++ b/site/login.html
@@ -33,8 +33,14 @@
     <a href="#" id="logoutLink" style="display:none;">Logout</a>
   </nav>
   <form id="loginForm">
-    <input type="text" id="username" placeholder="Username" required>
-    <input type="password" id="password" placeholder="Password" required>
+    <label>
+      Username
+      <input type="text" id="username" placeholder="Username" aria-label="Username" required>
+    </label>
+    <label>
+      Password
+      <input type="password" id="password" placeholder="Password" aria-label="Password" required>
+    </label>
     <button type="submit">Login</button>
     <div id="error"></div>
   </form>

--- a/site/projects.html
+++ b/site/projects.html
@@ -60,20 +60,26 @@
 						<div class="inner">
 							<section>
 								<h2>Get in touch</h2>
-								<form method="post" action="/contact">
-									<div class="fields">
-										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
-										</div>
-										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
-										</div>
-										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
-										</div>
-									</div>
+                                                                <form method="post" action="/contact">
+                                                                        <div class="fields">
+                                                                               <div class="field half">
+                                                                               <label>Name
+                                                                               <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" />
+                                                                               </label>
+                                                                               </div>
+                                                                               <div class="field half">
+                                                                               <label>Email
+                                                                               <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" />
+                                                                               </label>
+                                                                               </div>
+                                                                               <div class="field">
+                                                                               <label>Message
+                                                                               <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea>
+                                                                               </label>
+                                                                               </div>
+                                                                        </div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/barcode-catalog.html
+++ b/site/projects/barcode-catalog.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/crypto-trading-bot.html
+++ b/site/projects/crypto-trading-bot.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/cyberpatriot.html
+++ b/site/projects/cyberpatriot.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/google-cybersecurity.html
+++ b/site/projects/google-cybersecurity.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/hackathons.html
+++ b/site/projects/hackathons.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/independent-study.html
+++ b/site/projects/independent-study.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/mlh-nsa-team.html
+++ b/site/projects/mlh-nsa-team.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/open-to-work.html
+++ b/site/projects/open-to-work.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/quantum-curious.html
+++ b/site/projects/quantum-curious.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/store-associate.html
+++ b/site/projects/store-associate.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/projects/us-navy-veteran.html
+++ b/site/projects/us-navy-veteran.html
@@ -62,17 +62,17 @@
 								<form method="post" action="/contact">
 									<div class="fields">
 										<div class="field half">
-											<input type="text" name="name" id="name" placeholder="Name" />
+											<label>Name <input type="text" name="name" id="name" placeholder="Name" aria-label="Name" /></label>
 										</div>
 										<div class="field half">
-											<input type="email" name="email" id="email" placeholder="Email" />
+											<label>Email <input type="email" name="email" id="email" placeholder="Email" aria-label="Email" /></label>
 										</div>
 										<div class="field">
-											<textarea name="message" id="message" placeholder="Message"></textarea>
+											<label>Message <textarea name="message" id="message" placeholder="Message" aria-label="Message"></textarea></label>
 										</div>
 									</div>
 									<ul class="actions">
-										<li><input type="submit" value="Send" class="primary" /></li>
+										<li><input type="submit" value="Send" class="primary" aria-label="Send" /></li>
 									</ul>
 								</form>
 							</section>

--- a/site/signup.html
+++ b/site/signup.html
@@ -23,8 +23,14 @@
     <h1 class="glitch">Ninvax Beta 🪐</h1>
     <p class="tagline">Join the revolution. Reframe your reality.</p>
     <form id="beta-signup" onsubmit="handleSignup(event)">
-      <input type="text" name="name" placeholder="Name" required>
-      <input type="email" name="email" placeholder="Email" required>
+      <label>
+        Name
+        <input type="text" name="name" placeholder="Name" aria-label="Name" required>
+      </label>
+      <label>
+        Email
+        <input type="email" name="email" placeholder="Email" aria-label="Email" required>
+      </label>
       <button type="submit" class="neon-button">Join Now</button>
     </form>
     <div id="confirmation" style="display:none;">


### PR DESCRIPTION
## Summary
- add form labels on static pages and Next.js contact form
- add keyboard focus styles for buttons, nav links and cards
- make strain cards focusable with tab support
- update CSS for visible outlines

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841c30c5e88331b625e98393e6995e