### PR TITLE
Add NINVAX backend scaffold

### DIFF
--- a/ninvax/.env
+++ b/ninvax/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://ninvax_user:supersecurepassword@localhost:5432/ninvax

--- a/ninvax/app/__init__.py
+++ b/ninvax/app/__init__.py
@@ -1,0 +1,1 @@
+# Ninvax backend initialization

--- a/ninvax/app/crud.py
+++ b/ninvax/app/crud.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+from . import models
+
+
+def create_user(db: Session, user_id: str, email: str, stripe_id: str = None):
+    user = models.User(id=user_id, email=email, stripe_id=stripe_id)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def get_user_by_email(db: Session, email: str):
+    return db.query(models.User).filter(models.User.email == email).first()
+
+
+def create_subscription(db: Session, sub_id: str, user_id: str, status: str):
+    subscription = models.Subscription(id=sub_id, user_id=user_id, status=status)
+    db.add(subscription)
+    db.commit()
+    db.refresh(subscription)
+    return subscription
+
+
+def create_flag(db: Session, flag_id: str, code: str, user_id: str = None):
+    flag = models.Flag(id=flag_id, code=code, user_id=user_id)
+    db.add(flag)
+    db.commit()
+    db.refresh(flag)
+    return flag

--- a/ninvax/app/database.py
+++ b/ninvax/app/database.py
@@ -1,0 +1,13 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/ninvax/app/models.py
+++ b/ninvax/app/models.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True)
+    email = Column(String, unique=True, nullable=False)
+    stripe_id = Column(String, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    flags = relationship("Flag", back_populates="user")
+    subscription = relationship("Subscription", uselist=False, back_populates="user")
+
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.id"), unique=True)
+    status = Column(String)
+    started_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    user = relationship("User", back_populates="subscription")
+
+class Flag(Base):
+    __tablename__ = "flags"
+
+    id = Column(String, primary_key=True)
+    code = Column(String, unique=True, nullable=False)
+    user_id = Column(String, ForeignKey("users.id"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="flags")

--- a/ninvax/app/seed.py
+++ b/ninvax/app/seed.py
@@ -1,0 +1,15 @@
+from .database import SessionLocal, engine
+from .models import Base, Flag
+import uuid
+
+Base.metadata.create_all(bind=engine)
+
+db = SessionLocal()
+try:
+    db.add_all([
+        Flag(id=str(uuid.uuid4()), code="FLAG{init_protocol_ninvax}"),
+        Flag(id=str(uuid.uuid4()), code="FLAG{ghostshell_activated}")
+    ])
+    db.commit()
+finally:
+    db.close()

--- a/ninvax/requirements.txt
+++ b/ninvax/requirements.txt
@@ -1,0 +1,3 @@
+sqlalchemy
+psycopg2-binary
+python-dotenv


### PR DESCRIPTION
## Summary
- scaffold backend folder for NINVAX
- add SQLAlchemy models, database setup, CRUD helpers
- create seed script with initial flags
- add requirements and example `.env`

## Testing
- `pip install -r ninvax/requirements.txt`
- `python -m app.seed` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688435f0054c8331a04b87e6d34cda7f