### PR TITLE
Refactor Python backend utilities

### DIFF
--- a/ninvax/app/__init__.py
+++ b/ninvax/app/__init__.py
@@ -1,1 +1,4 @@
-# Ninvax backend initialization
+"""Ninvax backend package."""
+
+# The package is intentionally lightweight. Importing this module ensures that
+# models and database helpers are available for external scripts or services.

--- a/ninvax/app/crud.py
+++ b/ninvax/app/crud.py
@@ -1,30 +1,83 @@
+"""Database CRUD helper functions."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+
 from . import models
 
 
-def create_user(db: Session, user_id: str, email: str, stripe_id: str = None):
-    user = models.User(id=user_id, email=email, stripe_id=stripe_id)
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
+def create_user(db: Session, email: str, stripe_id: Optional[str] = None) -> Optional[models.User]:
+    """Create a new user record if one does not already exist."""
+    existing = get_user_by_email(db, email)
+    if existing:
+        return existing
+
+    user = models.User(id=str(uuid.uuid4()), email=email, stripe_id=stripe_id)
+    try:
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+    except SQLAlchemyError:
+        db.rollback()
+        return None
 
 
-def get_user_by_email(db: Session, email: str):
+def get_user_by_email(db: Session, email: str) -> Optional[models.User]:
+    """Retrieve a user by email."""
     return db.query(models.User).filter(models.User.email == email).first()
 
 
-def create_subscription(db: Session, sub_id: str, user_id: str, status: str):
-    subscription = models.Subscription(id=sub_id, user_id=user_id, status=status)
-    db.add(subscription)
-    db.commit()
-    db.refresh(subscription)
-    return subscription
+def create_subscription(db: Session, user_id: str, status: str) -> Optional[models.Subscription]:
+    """Create a subscription for a user."""
+    sub = models.Subscription(id=str(uuid.uuid4()), user_id=user_id, status=status)
+    try:
+        db.add(sub)
+        db.commit()
+        db.refresh(sub)
+        return sub
+    except SQLAlchemyError:
+        db.rollback()
+        return None
 
 
-def create_flag(db: Session, flag_id: str, code: str, user_id: str = None):
-    flag = models.Flag(id=flag_id, code=code, user_id=user_id)
-    db.add(flag)
-    db.commit()
-    db.refresh(flag)
-    return flag
+def create_flag(db: Session, code: str, user_id: Optional[str] = None) -> Optional[models.Flag]:
+    """Create a flag."""
+    flag = models.Flag(id=str(uuid.uuid4()), code=code, user_id=user_id)
+    try:
+        db.add(flag)
+        db.commit()
+        db.refresh(flag)
+        return flag
+    except SQLAlchemyError:
+        db.rollback()
+        return None
+
+
+def submit_flag(db: Session, user_id: str, code: str) -> bool:
+    """Attempt to claim a flag for a user.
+
+    Returns True on success, False if the flag does not exist or is already claimed.
+    """
+    flag = db.query(models.Flag).filter(models.Flag.code == code).first()
+    if not flag or flag.user_id:
+        return False
+
+    try:
+        flag.user_id = user_id
+        db.commit()
+        return True
+    except SQLAlchemyError:
+        db.rollback()
+        return False
+
+
+def get_found_flags(db: Session, user_id: str) -> List[models.Flag]:
+    """Return all flags claimed by a user."""
+    return db.query(models.Flag).filter(models.Flag.user_id == user_id).all()
+

--- a/ninvax/app/database.py
+++ b/ninvax/app/database.py
@@ -1,13 +1,29 @@
+"""Database session and engine setup."""
+
+import logging
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
 
+
+log = logging.getLogger(__name__)
+
+# Load variables from a .env if present
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+# Provide a reasonable default so the application can still start for local
+# development if DATABASE_URL is not configured.  Using SQLite keeps the initial
+# setup simple while allowing production deployments to specify Postgres.
+DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite:///./ninvax.db"
+if not os.getenv("DATABASE_URL"):
+    log.warning(
+        "DATABASE_URL not found in environment, defaulting to local SQLite file"
+    )
 
+# Create SQLAlchemy engine and session factory
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+

--- a/ninvax/app/models.py
+++ b/ninvax/app/models.py
@@ -1,9 +1,14 @@
-from sqlalchemy import Column, String, DateTime, ForeignKey
+"""SQLAlchemy ORM models for the Ninvax backend."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from .database import Base
 
 class User(Base):
+    """Registered application user."""
+
     __tablename__ = "users"
 
     id = Column(String, primary_key=True)
@@ -12,9 +17,13 @@ class User(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     flags = relationship("Flag", back_populates="user")
-    subscription = relationship("Subscription", uselist=False, back_populates="user")
+    subscription = relationship(
+        "Subscription", uselist=False, back_populates="user"
+    )
 
 class Subscription(Base):
+    """User subscription status."""
+
     __tablename__ = "subscriptions"
 
     id = Column(String, primary_key=True)
@@ -26,6 +35,8 @@ class Subscription(Base):
     user = relationship("User", back_populates="subscription")
 
 class Flag(Base):
+    """Hidden flag that can be claimed by a user."""
+
     __tablename__ = "flags"
 
     id = Column(String, primary_key=True)
@@ -34,3 +45,4 @@ class Flag(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", back_populates="flags")
+

--- a/ninvax/app/seed.py
+++ b/ninvax/app/seed.py
@@ -1,15 +1,35 @@
+"""Initial database seeding script.
+
+This script is safe to run multiple times. Existing records will not be
+duplicated.
+"""
+
+import uuid
+
 from .database import SessionLocal, engine
 from .models import Base, Flag
-import uuid
 
 Base.metadata.create_all(bind=engine)
 
-db = SessionLocal()
-try:
-    db.add_all([
-        Flag(id=str(uuid.uuid4()), code="FLAG{init_protocol_ninvax}"),
-        Flag(id=str(uuid.uuid4()), code="FLAG{ghostshell_activated}")
-    ])
-    db.commit()
-finally:
-    db.close()
+FLAGS = [
+    "FLAG{init_protocol_ninvax}",
+    "FLAG{ghostshell_activated}",
+]
+
+
+def seed_flags() -> None:
+    """Insert seed flags if they do not already exist."""
+
+    db = SessionLocal()
+    try:
+        for code in FLAGS:
+            exists = db.query(Flag).filter(Flag.code == code).first()
+            if not exists:
+                db.add(Flag(id=str(uuid.uuid4()), code=code))
+        db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed_flags()

--- a/ninvax/app/services/__init__.py
+++ b/ninvax/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for business logic."""

--- a/ninvax/app/services/user_service.py
+++ b/ninvax/app/services/user_service.py
@@ -1,0 +1,15 @@
+"""High level user related operations."""
+
+from sqlalchemy.orm import Session
+
+from .. import crud
+
+
+def register_user(db: Session, email: str, stripe_id: str | None = None):
+    """Register a new user if needed and return the user instance."""
+    return crud.create_user(db, email, stripe_id=stripe_id)
+
+
+def claim_flag(db: Session, user_id: str, code: str) -> bool:
+    """Wrapper around :func:`crud.submit_flag`."""
+    return crud.submit_flag(db, user_id, code)

--- a/ninvax/requirements.txt
+++ b/ninvax/requirements.txt
@@ -1,3 +1,3 @@
-sqlalchemy
-psycopg2-binary
-python-dotenv
+sqlalchemy>=2.0
+psycopg2-binary>=2.9
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- improve SQLAlchemy configuration with logging and fallback
- add safe CRUD helpers with docstrings
- document models and package
- make seeding idempotent
- introduce small service layer
- pin dependency versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688438a1adc883319e28e2aa6b0c0d8a