### PR TITLE
Add FastAPI API routes

### DIFF
--- a/ninvax/app/api.py
+++ b/ninvax/app/api.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, engine
+from . import models, crud
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/submit_flag")
+def submit_flag(user_id: str, code: str, db: Session = Depends(get_db)):
+    """Claim a flag for the given user."""
+    success = crud.submit_flag(db, user_id, code)
+    if not success:
+        raise HTTPException(status_code=400, detail="Invalid flag or already claimed")
+    return {"status": "ok"}
+
+
+@app.get("/user/{user_id}")
+def get_user(user_id: str, db: Session = Depends(get_db)):
+    """Return user data by id."""
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {
+        "id": user.id,
+        "email": user.email,
+        "stripe_id": user.stripe_id,
+    }
+
+
+@app.get("/flags")
+def list_flags(db: Session = Depends(get_db)):
+    """List all flags."""
+    flags = crud.get_all_flags(db)
+    return [
+        {"id": f.id, "code": f.code, "user_id": f.user_id}
+        for f in flags
+    ]

--- a/ninvax/app/crud.py
+++ b/ninvax/app/crud.py
@@ -81,3 +81,13 @@ def get_found_flags(db: Session, user_id: str) -> List[models.Flag]:
     """Return all flags claimed by a user."""
     return db.query(models.Flag).filter(models.Flag.user_id == user_id).all()
 
+
+
+def get_user(db: Session, user_id: str) -> Optional[models.User]:
+    """Retrieve a user by ID."""
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def get_all_flags(db: Session) -> List[models.Flag]:
+    """Return all flags."""
+    return db.query(models.Flag).all()

--- a/ninvax/requirements.txt
+++ b/ninvax/requirements.txt
@@ -1,3 +1,5 @@
 sqlalchemy>=2.0
 psycopg2-binary>=2.9
 python-dotenv>=1.0
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- create FastAPI application with endpoints for submitting flags, retrieving users, and listing flags
- expose helper CRUD functions to fetch users and flags
- update Python requirements for FastAPI support

## Testing
- `python -m pip install -r ninvax/requirements.txt`
- `python -m py_compile ninvax/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688439b58394833190bacb4cc618fdeb