### PR TITLE
Add Stripe webhook handler

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -77,6 +77,26 @@ app.post('/purchase', async (req, res) => {
   res.json({});
 });
 
+// Stripe webhook handler
+app.post('/webhook', (req, res) => {
+  const event = req.body;
+
+  switch (event.type) {
+    case 'customer.subscription.created':
+      console.log(
+        `Subscription created for customer ${event.data.object.customer}`
+      );
+      break;
+    case 'customer.deleted':
+      console.log(`Customer deleted: ${event.data.object.id}`);
+      break;
+    default:
+      console.log(`Unhandled event type ${event.type}`);
+  }
+
+  res.json({ received: true });
+});
+
 app.listen(port, () => {
   console.log(`Backend running on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- add express route `/webhook` to handle Stripe events
- log `customer.subscription.created` and `customer.deleted` events

## Testing
- `pytest ai_bot/tests/test_scheduler.py -q`
- `npm test` in backend (fails: `Missing script: "test"`)

------
https://chatgpt.com/codex/tasks/task_e_68843aab270c8331a9fef797932b9771