### PR TITLE
Add favorites page and star toggle

### DIFF
--- a/frontend/components/Navbar.js
+++ b/frontend/components/Navbar.js
@@ -9,6 +9,7 @@ export default function Navbar() {
       <Link href="/blog" style={{ color: '#fff', marginRight: '1rem' }}>Blog</Link>
       <Link href="/products" style={{ color: '#fff', marginRight: '1rem' }}>Products</Link>
       <Link href="/contact" style={{ color: '#fff', marginRight: '1rem' }}>Contact</Link>
+      <Link href="/favorites" style={{ color: '#fff', marginRight: '1rem' }}>Favorites</Link>
       <Link href="/notes" style={{ color: '#fff' }}>Notes</Link>
     </nav>
   );

--- a/frontend/components/StrainCard.js
+++ b/frontend/components/StrainCard.js
@@ -1,4 +1,27 @@
+import { useEffect, useState } from 'react';
+
 export default function StrainCard({ name, price, store, thumbnail }) {
+  const [starred, setStarred] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const favs = JSON.parse(localStorage.getItem('starredStrains') || '[]');
+    setStarred(favs.includes(name));
+  }, [name]);
+
+  function toggleFavorite() {
+    if (typeof window === 'undefined') return;
+    let favs = JSON.parse(localStorage.getItem('starredStrains') || '[]');
+    if (favs.includes(name)) {
+      favs = favs.filter((n) => n !== name);
+      setStarred(false);
+    } else {
+      favs.push(name);
+      setStarred(true);
+    }
+    localStorage.setItem('starredStrains', JSON.stringify(favs));
+  }
+
   return (
     <div
       style={{
@@ -13,7 +36,16 @@ export default function StrainCard({ name, price, store, thumbnail }) {
     >
       {thumbnail && <div style={{ marginRight: '1rem' }}>{thumbnail}</div>}
       <div>
-        <h3 style={{ margin: '0 0 0.5rem 0' }}>{name}</h3>
+        <h3 style={{ margin: '0 0 0.5rem 0' }}>
+          {name}{' '}
+          <span
+            onClick={toggleFavorite}
+            style={{ cursor: 'pointer', marginLeft: '0.25rem' }}
+            aria-label={starred ? 'Remove from favorites' : 'Add to favorites'}
+          >
+            {starred ? '★' : '☆'}
+          </span>
+        </h3>
         <p style={{ margin: 0, fontWeight: 'bold' }}>${price}</p>
         <p style={{ margin: 0, color: '#555' }}>{store}</p>
       </div>

--- a/frontend/lib/posts.js
+++ b/frontend/lib/posts.js
@@ -1,7 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 
-const postsDir = path.join(process.cwd(), 'frontend', 'posts');
+// When Next.js runs in production the current working directory already points
+// to the `frontend` folder. Joining another `frontend` segment results in the
+// wrong path `frontend/frontend/posts` which causes `next build` to fail. Use
+// the `posts` directory relative to cwd instead.
+const postsDir = path.join(process.cwd(), 'posts');
 
 export function getAllPosts() {
   const files = fs.readdirSync(postsDir);

--- a/frontend/pages/favorites.js
+++ b/frontend/pages/favorites.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import StrainCard from '../components/StrainCard';
+
+export default function Favorites() {
+  const [strains, setStrains] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/products');
+      const data = await res.json();
+      const favs = JSON.parse(localStorage.getItem('starredStrains') || '[]');
+      setStrains(data.filter((p) => favs.includes(p.name)));
+    }
+    load();
+  }, []);
+
+  return (
+    <>
+      <Navbar />
+      <main style={{ padding: '2rem' }}>
+        <h1>Favorites</h1>
+        {strains.length === 0 ? (
+          <p>No favorites yet</p>
+        ) : (
+          strains.map((p) => (
+            <StrainCard
+              key={p.name}
+              name={p.name}
+              price={p.price}
+              store={p.store}
+              thumbnail={p.thumbnail}
+            />
+          ))
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add favorites page that shows starred strains
- allow marking strains as favorites with a star icon
- fix posts path so Next.js build works
- link to new favorites page in navbar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68843bf08370833183fb7a58bdbabd57