### PR TITLE
Add AI service badges

### DIFF
--- a/apps/site/about.html
+++ b/apps/site/about.html
@@ -27,11 +27,17 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
-  <div class="openai-credit">
-    <a href="https://openai.com" target="_blank" rel="noopener">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-    </a>
-    <span class="chatgpt-badge">Made with ChatGPT</span>
+  <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
   </div>
   <script src="assets/js/animations.js"></script>
   <script src="assets/js/auth.js"></script>

--- a/apps/site/assets/css/cyberpunk.css
+++ b/apps/site/assets/css/cyberpunk.css
@@ -171,8 +171,8 @@ body::before {
     z-index: 1;
 }
 
-/* ChatGPT credit */
-.openai-credit {
+/* AI credit badges */
+.ai-credit {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -180,19 +180,34 @@ body::before {
     margin: 2em 0;
 }
 
-.openai-logo {
+.openai-logo,
+.anthropic-logo,
+.gemini-logo,
+.cohere-logo,
+.mlh-sticker,
+.ninvax-logo {
     width: 32px;
     height: 32px;
+}
+
+.openai-logo {
     animation: spin 6s linear infinite;
 }
 
-.chatgpt-badge {
-    background: #fff;
-    color: #000;
+.chatgpt-badge,
+.anthropic-badge,
+.gemini-badge,
+.cohere-badge {
     padding: 4px 8px;
     border-radius: 6px;
     font-size: 0.9em;
+    color: #000;
+    background: #fff;
 }
+
+.anthropic-badge { background: #f5f0e6; }
+.gemini-badge { background: #ffce00; }
+.cohere-badge  { background: #6500ea; color: #fff; }
 
 @keyframes spin {
     from { transform: rotate(0deg); }

--- a/apps/site/assets/css/main.css
+++ b/apps/site/assets/css/main.css
@@ -3333,8 +3333,8 @@ button:focus {
 
 }
 
-/* ChatGPT credit */
-.openai-credit {
+/* AI credit badges */
+.ai-credit {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -3342,19 +3342,34 @@ button:focus {
     margin: 2em 0;
 }
 
-.openai-logo {
+.openai-logo,
+.anthropic-logo,
+.gemini-logo,
+.cohere-logo,
+.mlh-sticker,
+.ninvax-logo {
     width: 32px;
     height: 32px;
+}
+
+.openai-logo {
     animation: spin 6s linear infinite;
 }
 
-.chatgpt-badge {
-    background: #fff;
-    color: #000;
+.chatgpt-badge,
+.anthropic-badge,
+.gemini-badge,
+.cohere-badge {
     padding: 4px 8px;
     border-radius: 6px;
     font-size: 0.9em;
+    color: #000;
+    background: #fff;
 }
+
+.anthropic-badge { background: #f5f0e6; }
+.gemini-badge { background: #ffce00; }
+.cohere-badge  { background: #6500ea; color: #fff; }
 
 @keyframes spin {
     from { transform: rotate(0deg); }

--- a/apps/site/blog.html
+++ b/apps/site/blog.html
@@ -111,12 +111,18 @@
                             </ul>
                         </div>
                     </footer>
-                    <div class="openai-credit">
-                        <a href="https://openai.com" target="_blank" rel="noopener">
-                            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                        </a>
-                        <span class="chatgpt-badge">Made with ChatGPT</span>
-                    </div>
+                    <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
             </div>
 

--- a/apps/site/contact.html
+++ b/apps/site/contact.html
@@ -41,11 +41,17 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
-  <div class="openai-credit">
-    <a href="https://openai.com" target="_blank" rel="noopener">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-    </a>
-    <span class="chatgpt-badge">Made with ChatGPT</span>
+  <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
   </div>
   <script src="assets/js/animations.js"></script>
   <script src="assets/js/cyberpunk.js"></script>

--- a/apps/site/gallery.html
+++ b/apps/site/gallery.html
@@ -117,12 +117,18 @@
 							</ul>
 						</div>
                                         </footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/images/anthropic-logo.svg
+++ b/apps/site/images/anthropic-logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" rx="15" fill="#f5f0e6"/>
+  <text x="50" y="55" font-size="45" text-anchor="middle" fill="#000">A</text>
+</svg>

--- a/apps/site/images/cohere-logo.svg
+++ b/apps/site/images/cohere-logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" rx="20" fill="#6500ea"/>
+  <text x="50" y="60" font-size="40" text-anchor="middle" fill="#fff">C</text>
+</svg>

--- a/apps/site/images/gemini-logo.svg
+++ b/apps/site/images/gemini-logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#ffce00"/>
+  <text x="50" y="60" font-size="40" text-anchor="middle" fill="#000">G</text>
+</svg>

--- a/apps/site/images/mlh-sticker.svg
+++ b/apps/site/images/mlh-sticker.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="60" rx="10" fill="#FFD500"/>
+  <text x="50" y="40" font-size="32" text-anchor="middle" fill="#000">MLH</text>
+</svg>

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -158,7 +158,7 @@
             padding: 10px;
             color: #800080;
         }
-        .openai-credit {
+        .ai-credit {
             display: flex;
             justify-content: center;
             align-items: center;
@@ -435,12 +435,18 @@
     </script>
     <script src="assets/js/auth.js"></script>
     <footer>© 2025 Ninvax</footer>
-    <div class="openai-credit">
-        <a href="https://openai.com" target="_blank" rel="noopener">
-            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-        </a>
-        <span class="chatgpt-badge">Made with ChatGPT</span>
-    </div>
+    <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
     <div id="toast" class="toast"></div>
 </body>
 </html>

--- a/apps/site/projects.html
+++ b/apps/site/projects.html
@@ -102,12 +102,18 @@
 							</ul>
 						</div>
                                         </footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/barcode-catalog.html
+++ b/apps/site/projects/barcode-catalog.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/crypto-trading-bot.html
+++ b/apps/site/projects/crypto-trading-bot.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/cyberpatriot.html
+++ b/apps/site/projects/cyberpatriot.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/google-cybersecurity.html
+++ b/apps/site/projects/google-cybersecurity.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/hackathons.html
+++ b/apps/site/projects/hackathons.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/independent-study.html
+++ b/apps/site/projects/independent-study.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/mlh-nsa-team.html
+++ b/apps/site/projects/mlh-nsa-team.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/open-to-work.html
+++ b/apps/site/projects/open-to-work.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/quantum-curious.html
+++ b/apps/site/projects/quantum-curious.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/store-associate.html
+++ b/apps/site/projects/store-associate.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/projects/us-navy-veteran.html
+++ b/apps/site/projects/us-navy-veteran.html
@@ -95,12 +95,18 @@
 							</ul>
 						</div>
 					</footer>
-                                        <div class="openai-credit">
-                                            <a href="https://openai.com" target="_blank" rel="noopener">
-                                                <img src="../images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                            </a>
-                                            <span class="chatgpt-badge">Made with ChatGPT</span>
-                                        </div>
+                                        <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/resume.html
+++ b/apps/site/resume.html
@@ -219,12 +219,18 @@
 							</ul>
 						</div>
                                     </footer>
-                                    <div class="openai-credit">
-                                        <a href="https://openai.com" target="_blank" rel="noopener">
-                                            <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-                                        </a>
-                                        <span class="chatgpt-badge">Made with ChatGPT</span>
-                                    </div>
+                                    <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
+  </div>
 
 			</div>
 

--- a/apps/site/signup.html
+++ b/apps/site/signup.html
@@ -42,11 +42,17 @@
   <footer>
     <p>Ninvax 🪐 2025</p>
   </footer>
-  <div class="openai-credit">
-    <a href="https://openai.com" target="_blank" rel="noopener">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
-    </a>
-    <span class="chatgpt-badge">Made with ChatGPT</span>
+  <div class="ai-credit">
+    <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo">
+    <span class="chatgpt-badge">ChatGPT</span>
+    <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo">
+    <span class="anthropic-badge">Claude</span>
+    <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo">
+    <span class="gemini-badge">Gemini</span>
+    <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo">
+    <span class="cohere-badge">Cohere</span>
+    <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker">
+    <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo">
   </div>
   <script src="assets/js/cyberpunk.js"></script>
   <script src="assets/js/animations.js"></script>


### PR DESCRIPTION
## Summary
- add simple logos for more AI services
- update CSS to style ai-credit badges with MLH sticker and Ninvax logo
- replace ChatGPT credit sections across site pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844ae0f2088331a6eca3a21009e351