### PR TITLE
Fix footer duplicates in static site

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -201,36 +201,10 @@
         <div class="strain-list" id="strainList"></div>
 
         <form id="storeForm" class="store-form">
-            <label>
-                Strain name
-                <input type="text" id="name" placeholder="Strain name" aria-label="Strain name" required>
-            </label>
-            <label>
-                Price
-                <input type="number" id="price" placeholder="Price" step="0.01" aria-label="Price" required>
-            </label>
-            <label>
-                Store name
-                <input type="text" id="store" placeholder="Store name" aria-label="Store name" required>
-            </label>
-
-        <input type="text" class="search-bar" placeholder="Search strains..." id="searchInput">
-        <div class="strain-list" id="strainList"></div>
-
-        <form id="storeForm" class="store-form">
             <input type="text" id="name" placeholder="Strain name" required>
             <input type="number" id="price" placeholder="Price" step="0.01" required>
-
             <div id="priceError" class="error"></div>
-
-
-            <div id="priceError" class="error">Price must be > 0</div>
-
-            <div id="priceError" class="error">Price must be &gt; 0</div>
-
-
             <input type="text" id="store" placeholder="Store name" required>
-
             <button type="submit" class="submit-btn">Add Strain</button>
         </form>
     </main>


### PR DESCRIPTION
## Summary
- clean up duplicated form markup in `apps/site/index.html`

## Testing
- `npm test` (fails: missing script)
- `npm run build` in `apps/web`
- `npm start` in `apps/site`

------
https://chatgpt.com/codex/tasks/task_e_68844d2321948331ad482004c315c4e0