### PR TITLE
Add Android and React Native skeleton apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This repository hosts all projects that make up the Ninvax platform. Runtime app
 | Path | Description | How to Run |
 |------|-------------|------------|
 | [`apps/ios`](apps/ios) | Swift iOS application | Open `NinvaxApp.xcodeproj` in Xcode |
+| [`apps/android`](apps/android) | Kotlin Android application | Open in Android Studio |
 | [`apps/web`](apps/web) | Next.js frontend | `npm install && npm run dev` |
+| [`apps/react-native`](apps/react-native) | React Native mobile app | `npm install && npm start` |
 | [`apps/backend`](apps/backend) | FastAPI backend (`ninvax`) and legacy Express server | `uvicorn ninvax.app.api:app` or `cd express && npm start` |
 | [`apps/bot`](apps/bot) | Python AI bot utilities | `pip install -r requirements.txt && python bootstrap.py` |
 | [`apps/site`](apps/site) | Static landing site and contact form | `node assets/js/server.js` or open `index.html` |

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -1,0 +1,6 @@
+# Ninvax Android App
+
+This folder contains a minimal Android project written in Kotlin. Open the
+`apps/android` directory in Android Studio to build and run the application.
+
+The project currently consists of a single `MainActivity` that displays a greeting.

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ninvax.android">
+    <application android:label="Ninvax Android">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/apps/android/app/src/main/java/com/ninvax/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/ninvax/android/MainActivity.kt
@@ -1,0 +1,14 @@
+package com.ninvax.android
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import android.widget.TextView
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val tv = TextView(this)
+        tv.text = "Hello, Ninvax Android!"
+        setContentView(tv)
+    }
+}

--- a/apps/react-native/App.js
+++ b/apps/react-native/App.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SafeAreaView, Text } from 'react-native';
+
+export default function App() {
+  return (
+    <SafeAreaView>
+      <Text>Hello from React Native!</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/react-native/README.md
+++ b/apps/react-native/README.md
@@ -1,0 +1,23 @@
+# Ninvax React Native App
+
+This folder contains a minimal React Native project. It uses the React Native CLI
+and should work on both iOS and Android.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the Metro bundler:
+   ```bash
+   npm start
+   ```
+3. To run on Android:
+   ```bash
+   npm run android
+   ```
+4. To run on iOS (requires Xcode):
+   ```bash
+   npm run ios
+   ```

--- a/apps/react-native/package.json
+++ b/apps/react-native/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ninvax-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic Android app with Kotlin `MainActivity`
- add React Native app with minimal `App.js` and package.json
- document new apps in the README

## Testing
- `pytest apps/bot/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68845a788f308331a714f4b9e48b34b1