### PR TITLE
Refine footer branding across static site

### DIFF
--- a/apps/site/about.html
+++ b/apps/site/about.html
@@ -35,25 +35,21 @@
       </p>
       <div class="saturn-ring-animation" style="display: none"></div>
     </div>
-    <footer>
-      <p>Ninvax 🪐 2025</p>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
     </footer>
-    <div class="ai-credit">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-      <span class="chatgpt-badge">ChatGPT</span>
-      <img
-        src="images/anthropic-logo.svg"
-        alt="Anthropic"
-        class="anthropic-logo"
-      />
-      <span class="anthropic-badge">Claude</span>
-      <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-      <span class="gemini-badge">Gemini</span>
-      <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-      <span class="cohere-badge">Cohere</span>
-      <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-      <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/auth.js"></script>
   </body>

--- a/apps/site/admin.html
+++ b/apps/site/admin.html
@@ -33,5 +33,20 @@
         window.location.href = "login.html";
       }
     </script>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
+    </footer>
   </body>
 </html>

--- a/apps/site/assets/css/cyberpunk.css
+++ b/apps/site/assets/css/cyberpunk.css
@@ -107,6 +107,14 @@ footer {
     margin-top: 40px;
 }
 
+.site-footer {
+    background: #111;
+    text-align: center;
+    color: #ff007a;
+    padding: 20px;
+    margin-top: 40px;
+}
+
 .glitch {
     position: relative;
 }
@@ -186,13 +194,14 @@ body::before {
 .cohere-logo,
 .mlh-sticker,
 .ninvax-logo {
-    animation: pulse-logo 3s ease-in-out infinite;
     width: 32px;
     height: 32px;
+    animation: none;
+    transition: transform 0.2s ease-in-out;
 }
 
-.openai-logo {
-    animation: spin 6s linear infinite;
+.ai-credit img:hover {
+    transform: scale(1.1);
 }
 
 .chatgpt-badge,
@@ -209,14 +218,3 @@ body::before {
 .anthropic-badge { background: #f5f0e6; }
 .gemini-badge { background: #ffce00; }
 .cohere-badge  { background: #6500ea; color: #fff; }
-
-@keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-}
-
-@keyframes pulse-logo {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.1); }
-  100% { transform: scale(1); }
-}

--- a/apps/site/contact.html
+++ b/apps/site/contact.html
@@ -64,25 +64,21 @@
         Thanks for reaching out!
       </div>
     </div>
-    <footer>
-      <p>Ninvax 🪐 2025</p>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
     </footer>
-    <div class="ai-credit">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-      <span class="chatgpt-badge">ChatGPT</span>
-      <img
-        src="images/anthropic-logo.svg"
-        alt="Anthropic"
-        class="anthropic-logo"
-      />
-      <span class="anthropic-badge">Claude</span>
-      <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-      <span class="gemini-badge">Gemini</span>
-      <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-      <span class="cohere-badge">Cohere</span>
-      <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-      <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/cyberpunk.js"></script>
     <script src="assets/js/auth.js"></script>

--- a/apps/site/create_account.html
+++ b/apps/site/create_account.html
@@ -80,25 +80,21 @@
         <button id="confirmNo" class="neon-button">No</button>
       </div>
     </div>
-    <footer>
-      <p>Ninvax 🪐 2025</p>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
     </footer>
-    <div class="ai-credit">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-      <span class="chatgpt-badge">ChatGPT</span>
-      <img
-        src="images/anthropic-logo.svg"
-        alt="Anthropic"
-        class="anthropic-logo"
-      />
-      <span class="anthropic-badge">Claude</span>
-      <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-      <span class="gemini-badge">Gemini</span>
-      <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-      <span class="cohere-badge">Cohere</span>
-      <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-      <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/auth.js"></script>
     <script>

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -420,23 +420,21 @@
       };
     </script>
     <script src="assets/js/auth.js"></script>
-    <footer>© 2025 Ninvax</footer>
-    <div class="ai-credit">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-      <span class="chatgpt-badge">ChatGPT</span>
-      <img
-        src="images/anthropic-logo.svg"
-        alt="Anthropic"
-        class="anthropic-logo"
-      />
-      <span class="anthropic-badge">Claude</span>
-      <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-      <span class="gemini-badge">Gemini</span>
-      <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-      <span class="cohere-badge">Cohere</span>
-      <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-      <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
+    </footer>
     <div id="toast" class="toast"></div>
   </body>
 </html>

--- a/apps/site/login.html
+++ b/apps/site/login.html
@@ -91,5 +91,20 @@
           }
         });
     </script>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
+    </footer>
   </body>
 </html>

--- a/apps/site/projects.html
+++ b/apps/site/projects.html
@@ -148,22 +148,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
 
     <!-- Scripts -->
     <script src="assets/js/animations.js"></script>

--- a/apps/site/projects/barcode-catalog.html
+++ b/apps/site/projects/barcode-catalog.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/crypto-trading-bot.html
+++ b/apps/site/projects/crypto-trading-bot.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/cyberpatriot.html
+++ b/apps/site/projects/cyberpatriot.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/google-cybersecurity.html
+++ b/apps/site/projects/google-cybersecurity.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/hackathons.html
+++ b/apps/site/projects/hackathons.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/independent-study.html
+++ b/apps/site/projects/independent-study.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/mlh-nsa-team.html
+++ b/apps/site/projects/mlh-nsa-team.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/open-to-work.html
+++ b/apps/site/projects/open-to-work.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/quantum-curious.html
+++ b/apps/site/projects/quantum-curious.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/store-associate.html
+++ b/apps/site/projects/store-associate.html
@@ -204,22 +204,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/projects/us-navy-veteran.html
+++ b/apps/site/projects/us-navy-veteran.html
@@ -201,22 +201,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
     </div>
 
     <!-- Scripts -->

--- a/apps/site/resume.html
+++ b/apps/site/resume.html
@@ -409,22 +409,21 @@
           </ul>
         </div>
       </footer>
-      <div class="ai-credit">
-        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-        <span class="chatgpt-badge">ChatGPT</span>
-        <img
-          src="images/anthropic-logo.svg"
-          alt="Anthropic"
-          class="anthropic-logo"
-        />
-        <span class="anthropic-badge">Claude</span>
-        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-        <span class="gemini-badge">Gemini</span>
-        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-        <span class="cohere-badge">Cohere</span>
-        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-      </div>
+      <footer class="site-footer">
+        <p>&copy; 2025 Ninvax</p>
+        <div class="ai-credit">
+          <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+          <span class="chatgpt-badge">ChatGPT</span>
+          <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+          <span class="anthropic-badge">Claude</span>
+          <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+          <span class="gemini-badge">Gemini</span>
+          <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+          <span class="cohere-badge">Cohere</span>
+          <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+          <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+        </div>
+      </footer>
 
     <!-- Scripts -->
     <script src="assets/js/animations.js"></script>

--- a/apps/site/signup.html
+++ b/apps/site/signup.html
@@ -60,25 +60,21 @@
       </div>
       <a href="index.html" class="neon-button">Back to Home</a>
     </div>
-    <footer>
-      <p>Ninvax 🪐 2025</p>
+    <footer class="site-footer">
+      <p>&copy; 2025 Ninvax</p>
+      <div class="ai-credit">
+        <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
+        <span class="chatgpt-badge">ChatGPT</span>
+        <img src="images/anthropic-logo.svg" alt="Anthropic" class="anthropic-logo" />
+        <span class="anthropic-badge">Claude</span>
+        <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
+        <span class="gemini-badge">Gemini</span>
+        <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
+        <span class="cohere-badge">Cohere</span>
+        <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
+        <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
+      </div>
     </footer>
-    <div class="ai-credit">
-      <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
-      <span class="chatgpt-badge">ChatGPT</span>
-      <img
-        src="images/anthropic-logo.svg"
-        alt="Anthropic"
-        class="anthropic-logo"
-      />
-      <span class="anthropic-badge">Claude</span>
-      <img src="images/gemini-logo.svg" alt="Gemini" class="gemini-logo" />
-      <span class="gemini-badge">Gemini</span>
-      <img src="images/cohere-logo.svg" alt="Cohere" class="cohere-logo" />
-      <span class="cohere-badge">Cohere</span>
-      <img src="images/mlh-sticker.svg" alt="MLH" class="mlh-sticker" />
-      <img src="images/logo.svg" alt="Ninvax" class="ninvax-logo" />
-    </div>
     <script src="assets/js/cyberpunk.js"></script>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/auth.js"></script>


### PR DESCRIPTION
## Summary
- standardize footer layout on all HTML pages
- update CSS for `.site-footer` and smoother AI logo effects
- add footer branding on admin and login pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888fc2fd65c83319bfb69fe36634712