### PR TITLE
Add AI partner logos to footer

### DIFF
--- a/apps/site/about.html
+++ b/apps/site/about.html
@@ -25,6 +25,20 @@
     </div>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/nav.js"></script>

--- a/apps/site/admin.html
+++ b/apps/site/admin.html
@@ -35,6 +35,20 @@
     </script>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
       <div class="ai-credit">
         <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
         <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/assets/css/cyberpunk.css
+++ b/apps/site/assets/css/cyberpunk.css
@@ -218,3 +218,21 @@ body::before {
 .anthropic-badge { background: #f5f0e6; }
 .gemini-badge { background: #ffce00; }
 .cohere-badge  { background: #6500ea; color: #fff; }
+.ai-logos {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1em;
+    margin-top: 10px;
+}
+
+.logo {
+    height: 40px;
+    width: auto;
+    transition: transform 0.2s ease-in-out;
+}
+
+.logo:hover {
+    transform: scale(1.1);
+}

--- a/apps/site/contact.html
+++ b/apps/site/contact.html
@@ -55,6 +55,20 @@
     </div>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/cyberpunk.js"></script>

--- a/apps/site/create_account.html
+++ b/apps/site/create_account.html
@@ -70,6 +70,20 @@
     </div>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/animations.js"></script>
     <script src="assets/js/nav.js"></script>

--- a/apps/site/favorites.html
+++ b/apps/site/favorites.html
@@ -14,6 +14,20 @@
     </main>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/nav.js"></script>
     <script>

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -415,6 +415,20 @@
       <script src="assets/js/nav.js"></script>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
       </footer>
     <div id="toast" class="toast"></div>
   </body>

--- a/apps/site/login.html
+++ b/apps/site/login.html
@@ -82,6 +82,20 @@
     </script>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/nav.js"></script>
   </body>

--- a/apps/site/projects.html
+++ b/apps/site/projects.html
@@ -141,6 +141,20 @@
       </footer>
         <footer class="site-footer">
           <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         </footer>
 
       <!-- Scripts -->

--- a/apps/site/projects/barcode-catalog.html
+++ b/apps/site/projects/barcode-catalog.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/crypto-trading-bot.html
+++ b/apps/site/projects/crypto-trading-bot.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/cyberpatriot.html
+++ b/apps/site/projects/cyberpatriot.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/google-cybersecurity.html
+++ b/apps/site/projects/google-cybersecurity.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/hackathons.html
+++ b/apps/site/projects/hackathons.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/independent-study.html
+++ b/apps/site/projects/independent-study.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/mlh-nsa-team.html
+++ b/apps/site/projects/mlh-nsa-team.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/open-to-work.html
+++ b/apps/site/projects/open-to-work.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/quantum-curious.html
+++ b/apps/site/projects/quantum-curious.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/store-associate.html
+++ b/apps/site/projects/store-associate.html
@@ -206,6 +206,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/projects/us-navy-veteran.html
+++ b/apps/site/projects/us-navy-veteran.html
@@ -203,6 +203,20 @@
       </footer>
       <footer class="site-footer">
         <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="../images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="../images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="../images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="../images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         <div class="ai-credit">
           <img src="images/openai-logo.svg" alt="OpenAI" class="openai-logo" />
           <span class="chatgpt-badge">ChatGPT</span>

--- a/apps/site/resume.html
+++ b/apps/site/resume.html
@@ -403,6 +403,20 @@
       </footer>
         <footer class="site-footer">
           <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
         </footer>
 
       <!-- Scripts -->

--- a/apps/site/signup.html
+++ b/apps/site/signup.html
@@ -51,6 +51,20 @@
     </div>
     <footer class="site-footer">
       <p>&copy; 2025 Ninvax</p>
+        <div class="ai-logos">
+          <a href="https://www.anthropic.com/" target="_blank" rel="noopener">
+            <img src="images/anthropic-icon-logo.png" alt="Anthropic" class="logo" />
+          </a>
+          <a href="https://cohere.com/" target="_blank" rel="noopener">
+            <img src="images/cohere-logo.png" alt="Cohere" class="logo" />
+          </a>
+          <a href="https://claude.ai/" target="_blank" rel="noopener">
+            <img src="images/claude-logo.png" alt="Claude" class="logo" />
+          </a>
+          <a href="https://mlh.io/" target="_blank" rel="noopener">
+            <img src="images/mlh-sticker.png" alt="Major League Hacking" class="logo" />
+          </a>
+        </div>
     </footer>
     <script src="assets/js/cyberpunk.js"></script>
     <script src="assets/js/animations.js"></script>


### PR DESCRIPTION
## Summary
- show partner logos for Anthropic, Cohere, Claude, and MLH in the site footer
- add new `.ai-logos` container and `.logo` styling

## Testing
- `node -v`
- `cd apps/site && npm install --silent && cd ../../`

------
https://chatgpt.com/codex/tasks/task_e_68891097faac833194f3b583390be7ab