### PR TITLE
Implement dynamic dashboard and AI tools

### DIFF
--- a/agents/emotion_reflector.py
+++ b/agents/emotion_reflector.py
@@ -1,0 +1,22 @@
+"""Emotion Reflector module.
+
+Analyzes text and returns mood scores with reflection prompts."""
+
+from typing import Dict
+
+
+def analyze_text(text: str) -> Dict[str, float]:
+    """Return simple mood scores for the supplied text."""
+    mood = {
+        "happy": text.lower().count("good"),
+        "sad": text.lower().count("bad"),
+    }
+    total = sum(mood.values()) or 1
+    return {k: v / total for k, v in mood.items()}
+
+
+def reflection_prompt(mood_scores: Dict[str, float]) -> str:
+    """Generate a short reflection prompt based on mood."""
+    if mood_scores.get("happy", 0) > mood_scores.get("sad", 0):
+        return "What made you feel positive today?"
+    return "What challenges did you face today?"

--- a/agents/personal_assistant.py
+++ b/agents/personal_assistant.py
@@ -1,0 +1,11 @@
+"""Personal Assistant pipeline powered by GPT-4.
+
+Combines scheduling, journaling and media curation tasks."""
+
+from typing import List
+
+
+def run_assistant_flow(goals: List[str]) -> str:
+    """Return a placeholder response summarizing assistant actions."""
+    summary = "; ".join(goals)
+    return f"Assistant planned tasks: {summary}"

--- a/agents/task_alchemy.py
+++ b/agents/task_alchemy.py
@@ -1,0 +1,23 @@
+"""Task Alchemy module.
+
+Turns vague notes into structured tasks with time estimates and dependencies."""
+
+from typing import List, Dict
+
+
+def notes_to_tasks(notes: str) -> List[Dict[str, str]]:
+    """Convert free-form notes into structured task dictionaries.
+
+    Parameters
+    ----------
+    notes: str
+        Raw textual notes describing desired outcomes.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        Each task includes a description, estimated time and optional dependencies.
+    """
+    # Placeholder implementation
+    return [{"task": line.strip(), "estimate": "1h", "depends": []}
+            for line in notes.split("\n") if line.strip()]

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -1,6 +1,6 @@
 """SQLAlchemy ORM models for the Ninvax backend."""
 
-from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text, Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -20,6 +20,9 @@ class User(Base):
     subscription = relationship(
         "Subscription", uselist=False, back_populates="user"
     )
+    journal_entries = relationship("JournalEntry", back_populates="user")
+    mood_logs = relationship("MoodLog", back_populates="user")
+    ai_actions = relationship("AIAction", back_populates="user")
 
 class Subscription(Base):
     """User subscription status."""
@@ -45,4 +48,44 @@ class Flag(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", back_populates="flags")
+
+
+class JournalEntry(Base):
+    """Free-form journal text created by a user."""
+
+    __tablename__ = "journal_entries"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.id"))
+    content = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="journal_entries")
+
+
+class MoodLog(Base):
+    """Logs of mood with a numeric score."""
+
+    __tablename__ = "mood_logs"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.id"))
+    mood = Column(String)
+    score = Column(Integer)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="mood_logs")
+
+
+class AIAction(Base):
+    """Record of an action taken by the assistant."""
+
+    __tablename__ = "ai_actions"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.id"))
+    action = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="ai_actions")
 

--- a/apps/web/components/Navbar.js
+++ b/apps/web/components/Navbar.js
@@ -1,6 +1,21 @@
 import Link from 'next/link';
+import React, { useState, useEffect } from 'react';
+import ThemeToggle from './ThemeToggle';
+
+function useAuth() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    setLoggedIn(document.cookie.includes('auth='));
+  }, []);
+  return [loggedIn, () => {
+    document.cookie = 'auth=; Max-Age=0; path=/';
+    setLoggedIn(false);
+  }];
+}
 
 export default function Navbar() {
+  const [loggedIn, logout] = useAuth();
   return (
     <nav style={{ padding: '1rem', background: '#333' }}>
       <Link href="/" style={{ color: '#fff', fontWeight: 'bold', marginRight: '1rem' }}>
@@ -9,7 +24,16 @@ export default function Navbar() {
       <Link href="/products" style={{ color: '#fff', marginRight: '1rem' }}>Products</Link>
       <Link href="/contact" style={{ color: '#fff', marginRight: '1rem' }}>Contact</Link>
       <Link href="/favorites" style={{ color: '#fff', marginRight: '1rem' }}>Favorites</Link>
-      <Link href="/notes" style={{ color: '#fff' }}>Notes</Link>
+      <Link href="/notes" style={{ color: '#fff', marginRight: '1rem' }}>Notes</Link>
+      {loggedIn ? (
+        <>
+          <Link href="/dashboard" style={{ color: '#fff', marginRight: '1rem' }}>Dashboard</Link>
+          <button onClick={logout} style={{ marginRight: '1rem' }}>Logout</button>
+        </>
+      ) : (
+        <Link href="/login" style={{ color: '#fff', marginRight: '1rem' }}>Login</Link>
+      )}
+      <ThemeToggle loggedIn={loggedIn} />
     </nav>
   );
 }

--- a/apps/web/components/ThemeToggle.js
+++ b/apps/web/components/ThemeToggle.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export default function ThemeToggle({ loggedIn }) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    document.body.dataset.theme = localStorage.getItem('theme') || 'light';
+  }, []);
+
+  function toggle() {
+    const next = document.body.dataset.theme === 'light' ? 'dark' : 'light';
+    document.body.dataset.theme = next;
+    localStorage.setItem('theme', next);
+  }
+
+  if (!loggedIn) return null;
+  return <button onClick={toggle}>Toggle Theme</button>;
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,7 +11,8 @@
         "next": "14.2.1",
         "nodemailer": "^6.9.4",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "swr": "^2.2.0"
       }
     },
     "node_modules/@next/env": {
@@ -216,6 +217,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -426,11 +436,33 @@
         }
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "next": "14.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "nodemailer": "^6.9.4"
+    "nodemailer": "^6.9.4",
+    "swr": "^2.2.0"
   }
 }

--- a/apps/web/pages/_app.js
+++ b/apps/web/pages/_app.js
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import Script from 'next/script';
+import '../styles.css';
 
 export default function App({ Component, pageProps }) {
   return (

--- a/apps/web/pages/admin.js
+++ b/apps/web/pages/admin.js
@@ -1,0 +1,13 @@
+import Navbar from '../components/Navbar';
+
+export default function Admin() {
+  return (
+    <>
+      <Navbar />
+      <div style={{padding:'2rem'}}>
+        <h1>Admin Panel</h1>
+        <p>Future management interface.</p>
+      </div>
+    </>
+  );
+}

--- a/apps/web/pages/api/data.js
+++ b/apps/web/pages/api/data.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req, res) {
+  const base = path.join(process.cwd(), 'data');
+  const mood_logs = JSON.parse(fs.readFileSync(path.join(base, 'mood_logs.json')));
+  const journal_entries = JSON.parse(fs.readFileSync(path.join(base, 'journal_entries.json')));
+  const assistant_actions = JSON.parse(fs.readFileSync(path.join(base, 'assistant_actions.json')));
+  res.status(200).json({ mood_logs, journal_entries, assistant_actions });
+}

--- a/apps/web/pages/api/login.js
+++ b/apps/web/pages/api/login.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { email, password } = req.body;
+  const usersPath = path.join(process.cwd(), 'data', 'users.json');
+  const users = JSON.parse(fs.readFileSync(usersPath, 'utf8'));
+  const user = users.find(u => u.email === email && u.password === password);
+  if (!user) return res.status(401).json({error:'invalid'});
+  res.setHeader('Set-Cookie', `auth=${user.id}; Path=/; HttpOnly`);
+  res.status(200).json({status:'ok'});
+}

--- a/apps/web/pages/dashboard.js
+++ b/apps/web/pages/dashboard.js
@@ -1,0 +1,36 @@
+import useSWR from 'swr';
+import Navbar from '../components/Navbar';
+
+const fetcher = (url) => fetch(url).then((r) => r.json());
+
+export default function Dashboard() {
+  const { data } = useSWR('/api/data', fetcher);
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <>
+      <Navbar />
+      <div style={{padding:'2rem'}}>
+        <h1>Dashboard</h1>
+        <h2>Mood Logs</h2>
+        <ul>
+          {data.mood_logs.map(m => (
+            <li key={m.id}>{m.mood} - {m.score}</li>
+          ))}
+        </ul>
+        <h2>Journal Entries</h2>
+        <ul>
+          {data.journal_entries.map(j => (
+            <li key={j.id}>{j.content}</li>
+          ))}
+        </ul>
+        <h2>Assistant Actions</h2>
+        <ul>
+          {data.assistant_actions.map(a => (
+            <li key={a.id}>{a.action}</li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/apps/web/pages/login.js
+++ b/apps/web/pages/login.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({email, password})
+    });
+    if (res.ok) router.push('/dashboard');
+    else alert('Login failed');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{padding:'2rem'}}>
+      <h1>Login</h1>
+      <input placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} />
+      <br />
+      <input type="password" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} />
+      <br />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1,0 +1,9 @@
+body[data-theme='dark'] {
+  background: #000;
+  color: #f0f0f0;
+}
+
+body[data-theme='light'] {
+  background: #fff;
+  color: #000;
+}

--- a/data/assistant_actions.json
+++ b/data/assistant_actions.json
@@ -1,0 +1,3 @@
+[
+  {"id": "1", "user_id": "1", "action": "Summarized your journal.", "created_at": "2023-10-10T10:06:00"}
+]

--- a/data/journal_entries.json
+++ b/data/journal_entries.json
@@ -1,0 +1,3 @@
+[
+  {"id": "1", "user_id": "1", "content": "Today was great!", "created_at": "2023-10-10T10:05:00"}
+]

--- a/data/mood_logs.json
+++ b/data/mood_logs.json
@@ -1,0 +1,3 @@
+[
+  {"id": "1", "user_id": "1", "mood": "happy", "score": 8, "created_at": "2023-10-10T10:00:00"}
+]

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,3 @@
+[
+  {"id": "1", "email": "test@example.com", "password": "password"}
+]


### PR DESCRIPTION
## Summary
- add basic AI modules under `agents/`
- extend SQLAlchemy models for journal entries, mood logs and actions
- implement simple login API reading from JSON
- add dashboard and admin pages in Next.js frontend
- include theme toggle shown when logged in
- provide placeholder data in `data/`

## Testing
- `npm install` and `npm run build` in `apps/web`
- `python -m py_compile agents/*.py apps/backend/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688a1ca6c7688331a6df24e210f0c52d