### PR TITLE
Add dark mode toggle with grayscale hover

### DIFF
--- a/apps/site/assets/css/theme.css
+++ b/apps/site/assets/css/theme.css
@@ -1,0 +1,42 @@
+body.light-mode {
+  background-color: #ffffff;
+  color: #000000;
+}
+body.light-mode nav {
+  background-color: #f2f2f2;
+}
+body.light-mode a {
+  color: #0000ee;
+}
+body.light-mode button {
+  background-color: #e0e0e0;
+  color: #000;
+}
+
+body.dark-mode {
+  background-color: #000000;
+  color: #ff00ff;
+}
+body.dark-mode nav {
+  background-color: #000000;
+}
+body.dark-mode a {
+  color: #ff66ff;
+}
+body.dark-mode button {
+  background-color: #ff00ff;
+  color: #000;
+}
+
+body img, body a, body button, body .strain-card, body .card {
+  filter: grayscale(100%);
+  transition: filter 0.3s ease;
+}
+
+body img:hover, body a:hover, body button:hover, body .strain-card:hover, body .card:hover {
+  filter: grayscale(0%);
+}
+
+body.dark-mode img:hover, body.dark-mode a:hover, body.dark-mode button:hover, body.dark-mode .strain-card:hover, body.dark-mode .card:hover {
+  filter: grayscale(0%) brightness(1.2);
+}

--- a/apps/site/assets/js/nav.js
+++ b/apps/site/assets/js/nav.js
@@ -8,5 +8,9 @@ window.addEventListener('DOMContentLoaded', () => {
       const script = document.createElement('script');
       script.src = 'assets/js/auth.js';
       document.body.appendChild(script);
+
+      const themeScript = document.createElement('script');
+      themeScript.src = 'assets/js/theme.js';
+      document.body.appendChild(themeScript);
     });
 });

--- a/apps/site/assets/js/theme.js
+++ b/apps/site/assets/js/theme.js
@@ -1,0 +1,49 @@
+function initThemeToggle() {
+  // inject theme stylesheet if not present
+  if (!document.getElementById('themeStyles')) {
+    const link = document.createElement('link');
+    link.id = 'themeStyles';
+    link.rel = 'stylesheet';
+    link.href = 'assets/css/theme.css';
+    document.head.appendChild(link);
+  }
+  const existing = document.getElementById('themeToggle');
+  if (existing) return; // prevent duplicates
+
+  const toggle = document.createElement('button');
+  toggle.id = 'themeToggle';
+  toggle.className = 'theme-toggle';
+  toggle.style.display = 'none';
+  toggle.style.position = 'fixed';
+  toggle.style.bottom = '10px';
+  toggle.style.right = '10px';
+  toggle.style.zIndex = '1001';
+  document.body.appendChild(toggle);
+
+  function apply(theme) {
+    document.body.classList.remove('dark-mode', 'light-mode');
+    document.body.classList.add(theme);
+    toggle.textContent = theme === 'dark-mode' ? '🌞' : '🌚';
+  }
+
+  const saved = localStorage.getItem('theme') || 'dark-mode';
+  apply(saved);
+
+  fetch('/current_user').then(r => r.ok ? r.json() : null).then(user => {
+    if (user) {
+      toggle.style.display = 'block';
+    }
+  }).catch(() => {});
+
+  toggle.addEventListener('click', () => {
+    const theme = document.body.classList.contains('dark-mode') ? 'light-mode' : 'dark-mode';
+    apply(theme);
+    localStorage.setItem('theme', theme);
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initThemeToggle);
+} else {
+  initThemeToggle();
+}


### PR DESCRIPTION
## Summary
- create `theme.css` for dark/light mode styling and grayscale hover effect
- add `theme.js` that shows a persistent 🌞/🌚 toggle when the user is logged in
- load `theme.js` from `nav.js` so every page can use it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a69fa157083319105d143541b3e6a