### PR TITLE
Add content generation scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "This repository contains the static files for the Ninvax website. The project is intentionally minimal and uses plain HTML, CSS and JavaScript.",
   "main": "generateContent.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate:metadata": "node scripts/generateMetadata.js",
+    "generate:pages": "node scripts/generatePage.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generateMetadata.js
+++ b/scripts/generateMetadata.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const { formatISO } = require('date-fns');
+const slugify = require('slugify');
+
+const baseDir = path.join(__dirname, '..', 'content');
+const postsDir = path.join(baseDir, 'posts');
+const assetDirs = ['images', 'videos', 'audio'];
+
+if (!fs.existsSync(postsDir)) {
+  fs.mkdirSync(postsDir, { recursive: true });
+}
+
+function inferTags(name) {
+  return name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(s => s.toLowerCase());
+}
+
+function readDescription(dir, base) {
+  const variants = [
+    `${base}.description.txt`,
+    `${base}.meta`,
+    `${base}.txt`,
+  ];
+  for (const f of variants) {
+    const p = path.join(dir, f);
+    if (fs.existsSync(p) && fs.statSync(p).isFile()) {
+      return fs.readFileSync(p, 'utf8').trim();
+    }
+  }
+  return '';
+}
+
+assetDirs.forEach(type => {
+  const dir = path.join(baseDir, type);
+  if (!fs.existsSync(dir)) return;
+  fs.readdirSync(dir).forEach(file => {
+    if (file.startsWith('.')) return;
+    const filePath = path.join(dir, file);
+    if (!fs.statSync(filePath).isFile()) return;
+
+    const ext = path.extname(file);
+    const base = path.basename(file, ext);
+    const slug = slugify(base, { lower: true, strict: true });
+    const dest = path.join(postsDir, `${slug}.json`);
+
+    const stat = fs.statSync(filePath);
+
+    const metadata = {
+      filename: file,
+      extension: ext,
+      type,
+      title: base.replace(/[-_]/g, ' '),
+      tags: inferTags(base),
+      createdAt: formatISO(stat.birthtime || stat.mtime),
+      description: readDescription(dir, base)
+    };
+
+    fs.writeFileSync(dest, JSON.stringify(metadata, null, 2));
+    console.log(`Created metadata for ${file}`);
+  });
+});

--- a/scripts/generatePage.js
+++ b/scripts/generatePage.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const postsDir = path.join(__dirname, '..', 'content', 'posts');
+const templatesDir = path.join(__dirname, '..', 'templates');
+const layout = fs.readFileSync(path.join(templatesDir, 'layout.html'), 'utf8');
+const outDir = path.join(__dirname, '..', 'posts');
+
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+function buildContent(post) {
+  const mediaPath = path.posix.join('content', post.type, post.filename);
+  let media = '';
+  if (post.type === 'images') {
+    media = `<img src="/${mediaPath}" alt="${post.title}" />`;
+  } else if (post.type === 'videos') {
+    media = `<video controls src="/${mediaPath}"></video>`;
+  } else if (post.type === 'audio') {
+    media = `<audio controls src="/${mediaPath}"></audio>`;
+  }
+  const tags = post.tags && post.tags.length ? `<p>Tags: ${post.tags.join(', ')}</p>` : '';
+  const desc = post.description ? `<p>${post.description}</p>` : '';
+  return `<h1>${post.title}</h1>\n${media}\n${desc}\n${tags}`;
+}
+
+fs.readdirSync(postsDir).forEach(file => {
+  if (!file.endsWith('.json')) return;
+  const post = JSON.parse(fs.readFileSync(path.join(postsDir, file), 'utf8'));
+  const content = buildContent(post);
+  const page = layout.replace('{{title}}', post.title).replace('{{content}}', content);
+  const dest = path.join(outDir, file.replace('.json', '.html'));
+  fs.writeFileSync(dest, page);
+  console.log(`Generated page ${dest}`);
+});

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{title}}</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <div id="nav"></div>
+    <script>
+      fetch('/components/nav.html')
+        .then(res => res.text())
+        .then(html => document.getElementById('nav').innerHTML = html);
+    </script>
+    <main>
+      {{content}}
+    </main>
+    <div id="footer"></div>
+    <script>
+      fetch('/components/footer.html')
+        .then(res => res.text())
+        .then(html => document.getElementById('footer').innerHTML = html);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create template layout for generated pages
- add generateMetadata.js to collect info on media files
- add generatePage.js to produce HTML from metadata
- wire scripts in `package.json`

## Testing
- `npm run generate:metadata`
- `npm run generate:pages`

------
https://chatgpt.com/codex/tasks/task_e_688ba94974a0833196a100e4ca59d4be