### PR TITLE
Restructure website layout and add placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,14 @@ This repository contains the static files for the Ninvax website. The project is
 ```
 public/           Static assets such as images
 components/       Reusable HTML snippets
+pages/            HTML page files
 styles/           Site-wide CSS
 scripts/          JavaScript modules
 data/             Static JSON data
-index.html        Home page
-timeline.html     Personal timeline
-resume.html       Resume
-about.html        About page
 ```
 
-Clone the repository and open `index.html` in your browser to view the site.
+Clone the repository and open `pages/index.html` in your browser to view the site.
 
 ## Legal
 
-All website content is © 2025 Ninvax and is provided for personal viewing only. See [Terms of Use](terms.html) for details.
+All website content is © 2025 Ninvax and is provided for personal viewing only. See [Terms of Use](pages/terms.html) for details.

--- a/components/footer.html
+++ b/components/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer">
   <p>&copy; 2025 Ninvax. All rights reserved.</p>
   <div class="ai-credit">Made with ChatGPT, Apple, and MLH.</div>
-  <a href="/terms.html">Terms of Use</a>
+  <a href="/pages/terms.html">Terms of Use</a>
 </footer>

--- a/components/nav.html
+++ b/components/nav.html
@@ -1,8 +1,13 @@
 <header class="site-header">
   <nav class="site-nav">
-    <a href="index.html">Home</a>
-    <a href="about.html">About</a>
-    <a href="timeline.html">Timeline</a>
-    <a href="resume.html">Resume</a>
+    <a href="/pages/index.html">Home</a>
+    <a href="/pages/about.html">About</a>
+    <a href="/pages/timeline.html">Timeline</a>
+    <a href="/pages/resume.html">Resume</a>
+    <a href="/pages/hackathons.html">Hackathons</a>
+    <a href="/pages/learn.html">Learn</a>
+    <a href="/pages/vision.html">Vision</a>
+    <a href="/pages/forum.html">Forum</a>
+    <button id="theme-toggle" hidden>🌗</button>
   </nav>
 </header>

--- a/data/forum-posts.json
+++ b/data/forum-posts.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "user": "anon",
+    "title": "First post",
+    "content": "Welcome to the forum"
+  }
+]

--- a/data/hackathons.json
+++ b/data/hackathons.json
@@ -1,0 +1,9 @@
+[
+  {
+    "title": "MiniHack 2025",
+    "ageRange": "10-14",
+    "location": "Online",
+    "date": "2025-09-15",
+    "theme": "Retro Game Mods"
+  }
+]

--- a/data/members.json
+++ b/data/members.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Jane Doe",
+    "role": "Founder"
+  }
+]

--- a/pages/about.html
+++ b/pages/about.html
@@ -8,17 +8,13 @@
       href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="stylesheet" href="/styles/main.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
   </head>
   <body>
     <div id="nav"></div>
-    <script>
-fetch('/components/nav.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('nav').innerHTML = html);
-    </script>
+    <script src="/scripts/load-nav.js"></script>
     <div class="container fade-slide-up">
       <h1 class="glitch">About Ninvax</h1>
       <p class="about-text">
@@ -26,15 +22,11 @@ fetch('/components/nav.html')
         hacking reality from Saturn's orbit to the cosmos 🪐.
         We craft glitchy tools that help outsiders bend the rules.
       </p>
-      <div class="saturn-ring-animation" style="display: none"></div>
+      <div class="saturn-ring-animation hidden"></div>
     </div>
     <div id="footer"></div>
-    <script>
-fetch('/components/footer.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('footer').innerHTML = html);
-    </script>
-    <script type="module" src="scripts/theme-toggle.js"></script>
-    <script type="module" src="scripts/grayscale-hover.js"></script>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
   </body>
 </html>

--- a/pages/forum.html
+++ b/pages/forum.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Forum - Ninvax</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <div id="nav"></div>
+    <script src="/scripts/load-nav.js"></script>
+    <main class="container">
+      <h1>Forum</h1>
+      <p>Exclusive hacker forum — coming soon</p>
+    </main>
+    <div id="footer"></div>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/hackathons.html
+++ b/pages/hackathons.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hackathons - Ninvax</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <div id="nav"></div>
+    <script src="/scripts/load-nav.js"></script>
+    <main class="container">
+      <h1>Hackathons</h1>
+      <p>Hackathons across age groups</p>
+    </main>
+    <div id="footer"></div>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -8,16 +8,12 @@
       href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="stylesheet" href="/styles/main.css" />
   </head>
   <body>
     <div class="intro-banner">Ninvax 🪐 Reality Hackers Unite</div>
     <div id="nav"></div>
-    <script>
-fetch('/components/nav.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('nav').innerHTML = html);
-    </script>
+    <script src="/scripts/load-nav.js"></script>
     <main>
       <section class="container hero-section">
         <h1>Ninvax Empire</h1>
@@ -233,15 +229,11 @@ fetch('/components/nav.html')
           }
       };
     </script>
-    <script src="scripts/render-products.js"></script>
-    <script type="module" src="scripts/theme-toggle.js"></script>
-    <script type="module" src="scripts/grayscale-hover.js"></script>
+    <script src="/scripts/render-products.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
     <div id="footer"></div>
-    <script>
-fetch('/components/footer.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('footer').innerHTML = html);
-    </script>
+    <script src="/scripts/load-footer.js"></script>
     <div id="toast" class="toast"></div>
   </body>
 </html>

--- a/pages/learn.html
+++ b/pages/learn.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Learn - Ninvax</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <div id="nav"></div>
+    <script src="/scripts/load-nav.js"></script>
+    <main class="container">
+      <h1>Learn</h1>
+      <p>Why CS should be a core subject</p>
+    </main>
+    <div id="footer"></div>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -8,22 +8,18 @@
       href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="stylesheet" href="/styles/main.css" />
   </head>
   <body>
       <div id="nav"></div>
-      <script>
-fetch('/components/nav.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('nav').innerHTML = html);
-      </script>
+      <script src="/scripts/load-nav.js"></script>
     <div class="container">
       <h1 class="glitch">Resume</h1>
       <nav id="toc" class="strain-list">
         <a href="#experience">Experience</a> |
         <a href="#education">Education</a>
       </nav>
-          <span class="image main"><img src="public/images/pic09.jpg" alt="" /></span>
+          <span class="image main"><img src="/public/images/pic09.jpg" alt="" /></span>
           <section>
             <h2>AI Prompt Engineer / Cognitive Systems Designer</h2>
             <p>
@@ -316,7 +312,7 @@ fetch('/components/nav.html')
     </div>
 
       <!-- Footer -->
-      <footer id="footer">
+      <footer id="resume-footer">
         <div class="inner">
           <section>
             <h2>Get in touch</h2>
@@ -407,14 +403,10 @@ fetch('/components/nav.html')
         </div>
       </footer>
         <div id="footer"></div>
-        <script>
-fetch('/components/footer.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('footer').innerHTML = html);
-        </script>
+        <script src="/scripts/load-footer.js"></script>
 
       <!-- Scripts -->
-      <script type="module" src="scripts/theme-toggle.js"></script>
-      <script type="module" src="scripts/grayscale-hover.js"></script>
+      <script src="/scripts/theme-toggle.js"></script>
+      <script type="module" src="/scripts/grayscale-hover.js"></script>
 </body>
 </html>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -4,25 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms of Use</title>
-    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="stylesheet" href="/styles/main.css" />
   </head>
   <body>
     <div id="nav"></div>
-    <script>
-fetch('/components/nav.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('nav').innerHTML = html);
-    </script>
+    <script src="/scripts/load-nav.js"></script>
     <main class="container">
       <h1>Terms of Use</h1>
       <p>All content on this website is &copy; 2025 Ninvax. All rights reserved. You may not reproduce, distribute, or adapt any material without prior written consent.</p>
       <p>If you believe content from this site has been used without permission, please contact us at <a href="mailto:info@ninvax.com">info@ninvax.com</a>.</p>
     </main>
     <div id="footer"></div>
-    <script>
-fetch('/components/footer.html')
-  .then(res => res.text())
-  .then(html => document.getElementById('footer').innerHTML = html);
-    </script>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
   </body>
 </html>

--- a/pages/timeline.html
+++ b/pages/timeline.html
@@ -4,10 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>NINVAX // Timeline</title>
-  <link rel="stylesheet" href="styles/timeline.css" />
-  <script src="scripts/terminal.js" defer></script>
+  <link rel="stylesheet" href="/styles/timeline.css" />
+  <script src="/scripts/terminal.js" defer></script>
 </head>
 <body>
+
+  <div id="nav"></div>
+  <script src="/scripts/load-nav.js"></script>
 
   <div id="boot-screen">
     <h1 class="typing">[booting system… NINVAX kernel v0.0.2000]</h1>
@@ -59,9 +62,9 @@
 
   </main>
 
-  <footer>
-    <p><a href="/">Back to Core</a> • <a href="https://x.com/YOURHANDLE">X Thread</a></p>
-  </footer>
-
+  <div id="footer"></div>
+  <script src="/scripts/load-footer.js"></script>
+  <script src="/scripts/theme-toggle.js"></script>
+  <script type="module" src="/scripts/grayscale-hover.js"></script>
 </body>
 </html>

--- a/pages/vision.html
+++ b/pages/vision.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vision - Ninvax</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+  <body>
+    <div id="nav"></div>
+    <script src="/scripts/load-nav.js"></script>
+    <main class="container">
+      <h1>Vision</h1>
+      <p>Our mission for the future of tech</p>
+    </main>
+    <div id="footer"></div>
+    <script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/theme-toggle.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/scripts/load-footer.js
+++ b/scripts/load-footer.js
@@ -1,0 +1,6 @@
+fetch('/components/footer.html')
+  .then(res => res.text())
+  .then(html => {
+    const el = document.getElementById('footer');
+    if (el) el.innerHTML = html;
+  });

--- a/scripts/load-nav.js
+++ b/scripts/load-nav.js
@@ -1,0 +1,6 @@
+fetch('/components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    const el = document.getElementById('nav');
+    if (el) el.innerHTML = html;
+  });

--- a/scripts/theme-toggle.js
+++ b/scripts/theme-toggle.js
@@ -1,49 +1,13 @@
-function initThemeToggle() {
-  // inject theme stylesheet if not present
-  if (!document.getElementById('themeStyles')) {
-    const link = document.createElement('link');
-    link.id = 'themeStyles';
-    link.rel = 'stylesheet';
-    link.href = 'assets/css/theme.css';
-    document.head.appendChild(link);
-  }
-  const existing = document.getElementById('themeToggle');
-  if (existing) return; // prevent duplicates
+const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+const btn = document.getElementById('theme-toggle');
 
-  const toggle = document.createElement('button');
-  toggle.id = 'themeToggle';
-  toggle.className = 'theme-toggle';
-  toggle.style.display = 'none';
-  toggle.style.position = 'fixed';
-  toggle.style.bottom = '10px';
-  toggle.style.right = '10px';
-  toggle.style.zIndex = '1001';
-  document.body.appendChild(toggle);
+if (isLoggedIn) btn.hidden = false;
 
-  function apply(theme) {
-    document.body.classList.remove('dark-mode', 'light-mode');
-    document.body.classList.add(theme);
-    toggle.textContent = theme === 'dark-mode' ? '🌞' : '🌚';
-  }
+btn.addEventListener('click', () => {
+  document.body.classList.toggle('dark-mode');
+  localStorage.setItem('theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+});
 
-  const saved = localStorage.getItem('theme') || 'dark-mode';
-  apply(saved);
-
-  fetch('/current_user').then(r => r.ok ? r.json() : null).then(user => {
-    if (user) {
-      toggle.style.display = 'block';
-    }
-  }).catch(() => {});
-
-  toggle.addEventListener('click', () => {
-    const theme = document.body.classList.contains('dark-mode') ? 'light-mode' : 'dark-mode';
-    apply(theme);
-    localStorage.setItem('theme', theme);
-  });
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initThemeToggle);
-} else {
-  initThemeToggle();
+if (localStorage.getItem('theme') === 'dark') {
+  document.body.classList.add('dark-mode');
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -279,3 +279,18 @@ body::before {
 .hidden {
     display: none;
 }
+* {
+  transition: filter 0.2s ease;
+}
+
+.grayscale-hover img,
+.grayscale-hover button,
+.grayscale-hover a {
+  filter: grayscale(100%);
+}
+
+.grayscale-hover img:hover,
+.grayscale-hover button:hover,
+.grayscale-hover a:hover {
+  filter: grayscale(0%);
+}


### PR DESCRIPTION
## Summary
- organize HTML pages under `/pages`
- modularize nav and footer loading with new scripts
- add dark mode toggle button
- implement grayscale hover styles
- create placeholder feature pages and data stubs
- update README with new directory layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cd8f7e0ec833181ecc3f160eab140