### PR TITLE
Add mission, vision, and team sections to About page

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -1,6 +1,20 @@
 [
   {
     "name": "Jane Doe",
-    "role": "Founder"
+    "role": "Founder",
+    "category": "Key Members",
+    "bio": "Visionary behind Ninvax's cosmic mission."
+  },
+  {
+    "name": "John Smith",
+    "role": "Strategic Advisor",
+    "category": "Advisors",
+    "bio": "Guides long-term strategy across tech and culture."
+  },
+  {
+    "name": "Acme Labs",
+    "role": "Research Partner",
+    "category": "Strategic Partners",
+    "bio": "Collaborates on cutting-edge cannabis technology."
   }
 ]

--- a/pages/about.html
+++ b/pages/about.html
@@ -24,11 +24,24 @@
         hacking reality from Saturn's orbit to the cosmos 🪐.
         We craft glitchy tools that help outsiders bend the rules.
       </p>
+      <section id="mission">
+        <h2>Mission</h2>
+        <p>Elevate with Intention.</p>
+      </section>
+      <section id="vision">
+        <h2>Vision</h2>
+        <p>Futuristic intersection of cannabis, technology, and creativity.</p>
+      </section>
+      <section id="team">
+        <h2>Team</h2>
+        <div id="team-members"></div>
+      </section>
       <div class="saturn-ring-animation hidden"></div>
     </main>
 
     <div id="footer"></div><script src="/scripts/load-footer.js"></script>
     <!-- page‑specific scripts -->
+    <script src="/scripts/load-team.js"></script>
     <script src="/scripts/scroll-animate.js"></script>
     <script type="module" src="/scripts/grayscale-hover.js"></script>
   </body>

--- a/scripts/load-team.js
+++ b/scripts/load-team.js
@@ -1,0 +1,24 @@
+fetch('/data/members.json')
+  .then(res => res.json())
+  .then(data => {
+    const container = document.getElementById('team-members');
+    if (!container) return;
+    const categories = ['Key Members', 'Advisors', 'Strategic Partners'];
+    categories.forEach(cat => {
+      const group = data.filter(m => m.category === cat);
+      if (group.length === 0) return;
+      const section = document.createElement('section');
+      const heading = document.createElement('h3');
+      heading.textContent = cat;
+      section.appendChild(heading);
+      const list = document.createElement('ul');
+      group.forEach(m => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>${m.name}</strong> – ${m.role}<br><span>${m.bio}</span>`;
+        list.appendChild(li);
+      });
+      section.appendChild(list);
+      container.appendChild(section);
+    });
+  })
+  .catch(err => console.error('Error loading team members', err));


### PR DESCRIPTION
## Summary
- add mission, vision, and team sections to About page
- include client-side script to render team members from JSON
- expand team data with members, advisors, and partners

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run generate:metadata`
- `npm run generate:pages`


------
https://chatgpt.com/codex/tasks/task_e_688e7a5d15b883319944d86336a24f23