### PR TITLE
Add business plan page with pitch deck and calculators

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -9,6 +9,7 @@
       <li><a href="/pages/hackathons.html">Hackathons</a></li>
       <li><a href="/pages/learn.html">Learn</a></li>
       <li><a href="/pages/vision.html">Vision</a></li>
+      <li><a href="/pages/investment.html">Business Plan</a></li>
       <li><a href="/pages/forum.html">Forum</a></li>
       <li><button id="theme-toggle" hidden>🌗</button></li>
     </ul>

--- a/pages/investment.html
+++ b/pages/investment.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Business Plan & Investment - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+    <main class="container fade-slide-up">
+      <h1 class="glitch" data-text="Business Plan & Investment">Business Plan & Investment</h1>
+
+      <section id="pitch">
+        <h2>Pitch Deck</h2>
+        <iframe src="/public/pitch-deck.pdf" width="100%" height="400" title="Pitch Deck"></iframe>
+      </section>
+
+      <section id="download">
+        <h2>Business Plan</h2>
+        <p><a href="/public/business-plan.pdf" download>Download Business Plan (PDF)</a></p>
+      </section>
+
+      <section id="financial">
+        <h2>Financial Projections</h2>
+        <form id="calc-form" class="calc-form">
+          <label>Units Sold <input type="number" id="units" min="0" step="1"></label>
+          <label>Price per Unit ($) <input type="number" id="price" min="0" step="0.01"></label>
+          <label>Cost per Unit ($) <input type="number" id="cost" min="0" step="0.01"></label>
+        </form>
+        <p>Projected Revenue: $<span id="revenue">0.00</span></p>
+        <p>Projected Profit: $<span id="profit">0.00</span></p>
+      </section>
+
+      <section id="inquiry">
+        <h2>Investment Inquiries</h2>
+        <form id="invest-form" action="#" method="post">
+          <label>Name <input type="text" name="name" required></label>
+          <label>Email <input type="email" name="email" required></label>
+          <label>Message <textarea name="message" required></textarea></label>
+          <button type="submit">Submit</button>
+        </form>
+      </section>
+
+      <section id="disclaimer">
+        <h2>Legal Disclaimer</h2>
+        <p>Information provided is for informational purposes only and does not constitute an offer to sell securities. Cannabis-related investments involve significant risk and may be restricted by law.</p>
+        <p>Prospective investors should consult legal and financial advisors before making investment decisions.</p>
+      </section>
+    </main>
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/financial-calculator.js"></script>
+  </body>
+</html>

--- a/public/business-plan.pdf
+++ b/public/business-plan.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250802210207+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250802210207+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 192
+>>
+stream
+GarW15n8K#&4Q>`i\/h!U^b^7M6>@<kQN:e,fMMr'StW&@T[_\B'(c',k!5tERZZ-*iKJW(BpXD>,X20@BMSZCur61\5&u+"Xb<LIX>o!<b?ZQRXu7a!=q]+L$;ugM<\G:,!3eKA2bEu4G&7A-ePZD^ba0Pk^C?$ncl32P1l):C[`@rU\,8jU_28rjF]RF~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<fabc84cbd21040f86743a17e939971ed><fabc84cbd21040f86743a17e939971ed>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1109
+%%EOF

--- a/public/pitch-deck.pdf
+++ b/public/pitch-deck.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250802210207+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250802210207+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 116
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CZ51'!.M+c.+(%59^B,+rbTJqdWE?<L`k69o-SEe]0=C3$b[6:dD/L_`O:!Z(iTg)83~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<96276bd4471a991e2670b271eb10633e><96276bd4471a991e2670b271eb10633e>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1033
+%%EOF

--- a/scripts/financial-calculator.js
+++ b/scripts/financial-calculator.js
@@ -1,0 +1,27 @@
+// Simple financial projection calculator
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('calc-form');
+  if (!form) return;
+  const units = form.querySelector('#units');
+  const price = form.querySelector('#price');
+  const cost = form.querySelector('#cost');
+  const revenueEl = document.getElementById('revenue');
+  const profitEl = document.getElementById('profit');
+
+  function update() {
+    const u = parseFloat(units.value) || 0;
+    const p = parseFloat(price.value) || 0;
+    const c = parseFloat(cost.value) || 0;
+    const revenue = u * p;
+    const profit = revenue - u * c;
+    revenueEl.textContent = revenue.toFixed(2);
+    profitEl.textContent = profit.toFixed(2);
+  }
+
+  [units, price, cost].forEach(el => el.addEventListener('input', update));
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    update();
+  });
+});


### PR DESCRIPTION
## Summary
- add Business Plan & Investment page with embedded pitch deck, PDF plan download, financial calculators, inquiry form, and disclaimers
- add navigation link to new Business Plan page
- include simple financial calculator script and placeholder PDF assets

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688e7c2c43188331b97dfe4fb8003af2