### PR TITLE
Add Hackensack locations and licensing page

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -10,6 +10,7 @@
       <li><a href="/pages/learn.html">Learn</a></li>
       <li><a href="/pages/vision.html">Vision</a></li>
       <li><a href="/pages/investment.html">Business Plan</a></li>
+      <li><a href="/pages/hackensack.html">Locations &amp; Licensing</a></li>
       <li><a href="/pages/forum.html">Forum</a></li>
       <li><button id="theme-toggle" hidden>🌗</button></li>
     </ul>

--- a/pages/hackensack.html
+++ b/pages/hackensack.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Hackensack, NJ - Locations & Licensing - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+    <!-- extra head scripts per page -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+    <style>#map{height:400px;}</style>
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+
+    <!-- OPTIONAL hero banner -->
+    <!-- <section class="intro-banner">Ninvax 🪐 Reality Hackers Unite</section> -->
+
+    <main class="container fade-slide-up">
+      <!-- page‑specific content -->
+      <h1>Hackensack, NJ Locations & Licensing</h1>
+
+      <section id="map-section">
+        <h2>Interactive Map with Cannabis Overlay Zones</h2>
+        <div id="map"></div>
+        <p><small>Map boundaries are approximate. Consult official city resources for definitive zoning maps.</small></p>
+      </section>
+
+      <section id="zoning">
+        <h2>Current Zoning Status & Municipal Ordinances</h2>
+        <p>Hackensack permits cannabis businesses only within designated Cannabis Overlay Zones established by municipal ordinance. Operations must comply with local buffer requirements and all standard zoning rules. Refer to the city's <a href="https://ecode360.com/HA0315" target="_blank" rel="noopener">municipal code</a> for complete details.</p>
+      </section>
+
+      <section id="licensing">
+        <h2>Licensing Steps Checklist</h2>
+        <ol>
+          <li>Verify the property lies within a Cannabis Overlay Zone.</li>
+          <li>Review Hackensack's cannabis ordinance and zoning buffers.</li>
+          <li>Submit a conditional-use application to the Planning Board.</li>
+          <li>Obtain a municipal cannabis license from the city.</li>
+          <li>Apply for state licensure with the New Jersey Cannabis Regulatory Commission.</li>
+        </ol>
+      </section>
+
+      <section id="conditional-use">
+        <h2>Conditional-use Proposals & Updates</h2>
+        <p>The Planning Board reviews conditional-use proposals for cannabis facilities. Meeting agendas and decisions are posted on the city's <a href="https://www.hackensack.org/" target="_blank" rel="noopener">official website</a>, where the latest updates and public notices are available.</p>
+      </section>
+    </main>
+
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <!-- page‑specific scripts -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      const map = L.map('map').setView([40.885, -74.043], 14);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '&copy; OpenStreetMap contributors'}).addTo(map);
+      const overlay = L.polygon([
+        [40.892, -74.049],
+        [40.892, -74.033],
+        [40.878, -74.033],
+        [40.878, -74.049]
+      ], { color: 'green', fillOpacity: 0.2 }).addTo(map);
+      overlay.bindPopup('Cannabis Overlay Zone (approximate)');
+    </script>
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- link Locations & Licensing from nav
- add detailed Hackensack, NJ page with interactive map, zoning info, licensing checklist, and conditional-use updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e7d882ac483319ab25c52a64b31f8