### PR TITLE
Add technology, community, blog, and contact pages

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -13,6 +13,10 @@
       <li><a href="/pages/investment.html">Business Plan</a></li>
       <li><a href="/pages/hackensack.html">Locations &amp; Licensing</a></li>
       <li><a href="/pages/forum.html">Forum</a></li>
+      <li><a href="/pages/technology.html">Technology</a></li>
+      <li><a href="/pages/community.html">Community</a></li>
+      <li><a href="/pages/blog.html">Blog</a></li>
+      <li><a href="/pages/contact.html">Contact</a></li>
       <li><button id="theme-toggle" hidden>🌗</button></li>
     </ul>
   </nav>

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Blog & News - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+    <!-- extra head scripts per page -->
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+
+    <main class="container fade-slide-up">
+      <!-- page‑specific content -->
+      <h1 class="glitch" data-text="Blog &amp; News">Blog &amp; News</h1>
+
+      <section id="categories">
+        <h2>Categories</h2>
+        <ul>
+          <li>Cannabis policy &amp; regulations</li>
+          <li>Innovation &amp; technology updates</li>
+          <li>Community stories &amp; event recaps</li>
+        </ul>
+      </section>
+
+      <section id="pipeline">
+        <h2>Publishing Pipeline</h2>
+        <p>
+          Articles are drafted in Markdown, reviewed on GitHub, and deployed live via
+          Vercel or Netlify. Notion automations, powered by Codex, keep content flowing
+          regularly so members stay informed.
+        </p>
+      </section>
+
+      <section id="posts">
+        <h2>Latest Posts</h2>
+        <div id="blog-posts" class="placeholder">
+          <!-- Notion-powered posts will render here -->
+        </div>
+      </section>
+    </main>
+
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <!-- page‑specific scripts -->
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/community.html
+++ b/pages/community.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Community & Membership - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+    <!-- extra head scripts per page -->
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+
+    <main class="container fade-slide-up">
+      <!-- page‑specific content -->
+      <h1 class="glitch" data-text="Community &amp; Membership">Community &amp; Membership</h1>
+
+      <section id="signup">
+        <h2>Membership Sign‑up</h2>
+        <form id="membership-form">
+          <input type="text" name="name" placeholder="Name" required />
+          <input type="email" name="email" placeholder="Email" required />
+          <input type="text" name="wallet" placeholder="Wallet Address" required />
+          <select name="tier">
+            <option value="seed">Seed Tier</option>
+            <option value="bloom">Bloom Tier</option>
+            <option value="galaxy">Galaxy Tier</option>
+          </select>
+          <button type="submit" class="btn">Mint Membership NFT</button>
+        </form>
+        <div id="mint-status" class="placeholder">
+          <!-- NFT minting feedback will appear here -->
+        </div>
+      </section>
+
+      <section id="leaderboard">
+        <h2>Gamification Leaderboard</h2>
+        <p>
+          Member progression and rewards will be displayed in an interactive leaderboard.
+          Track challenges, earn points, and climb the ranks as features roll out.
+        </p>
+        <div id="leaderboard-placeholder" class="placeholder"></div>
+      </section>
+
+      <section id="community-links">
+        <h2>Join the Conversation</h2>
+        <p>Connect with fellow reality hackers in real time:</p>
+        <ul>
+          <li><a href="https://discord.com" target="_blank">Discord Community</a></li>
+          <li><a href="https://t.me" target="_blank">Telegram Channel</a></li>
+        </ul>
+      </section>
+    </main>
+
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <!-- page‑specific scripts -->
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Contact & Outreach - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+    <!-- extra head scripts per page -->
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+
+    <main class="container fade-slide-up">
+      <!-- page‑specific content -->
+      <h1 class="glitch" data-text="Contact &amp; Outreach">Contact &amp; Outreach</h1>
+
+      <section id="contact-forms">
+        <h2>Get in Touch</h2>
+        <form id="contact-form">
+          <input type="text" name="name" placeholder="Name" required />
+          <input type="email" name="email" placeholder="Email" required />
+          <select name="type" required>
+            <option value="investor">Investor</option>
+            <option value="municipality">Municipality</option>
+            <option value="partner">Partner</option>
+            <option value="general">General</option>
+          </select>
+          <textarea name="message" placeholder="Your message" rows="5" required></textarea>
+          <button type="submit" class="btn">Send</button>
+        </form>
+        <div id="crm-status" class="placeholder">
+          <!-- CRM integration status will appear here -->
+        </div>
+      </section>
+    </main>
+
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <!-- page‑specific scripts -->
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -26,9 +26,9 @@
           meets elevated cultivation.
         </p>
         <ul class="quick-links">
-          <li><a href="#">Investor Information</a></li>
-          <li><a href="#">Membership Signup</a></li>
-          <li><a href="#">Blog Highlights</a></li>
+          <li><a href="/pages/investment.html">Investor Information</a></li>
+          <li><a href="/pages/community.html">Membership Signup</a></li>
+          <li><a href="/pages/blog.html">Blog Highlights</a></li>
         </ul>
       </section>
       <section class="container hero-section scroll-fade">

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Technology & Innovation - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+    <!-- extra head scripts per page -->
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+
+    <main class="container fade-slide-up">
+      <!-- page‑specific content -->
+      <h1 class="glitch" data-text="Technology &amp; Innovation">Technology &amp; Innovation</h1>
+
+      <section id="digital-infrastructure">
+        <h2>Digital Infrastructure</h2>
+        <p>
+          A modular stack powers Ninvax from the ground up. Frontend experiences run on
+          static HTML enhanced with vanilla JavaScript, while Node.js and serverless APIs
+          handle backend logic. Architecture diagrams and design docs will be rendered
+          interactively, giving contributors a clear view of how systems connect.
+        </p>
+        <ul>
+          <li>Frontend: HTML, CSS, JavaScript</li>
+          <li>Backend: Node.js &amp; serverless functions</li>
+          <li>APIs: REST and Web3 integrations</li>
+          <li><a href="https://github.com/ninvax" target="_blank">Code repositories</a></li>
+        </ul>
+      </section>
+
+      <section id="blockchain-nfts">
+        <h2>Blockchain &amp; NFT Memberships</h2>
+        <p>
+          Membership tokens follow the ERC‑721 standard with rich metadata linking each NFT
+          to exclusive benefits. Tiers unlock perks from early product access to governance
+          votes. Future releases will visualize live mints and transactions via Web3 APIs.
+        </p>
+        <ul>
+          <li>ERC‑721 smart contracts with metadata integration</li>
+          <li>Tiered memberships and reward structures</li>
+          <li>Real‑time minting and transaction feeds (coming soon)</li>
+        </ul>
+        <div id="nft-visualizer" class="placeholder">
+          <!-- Web3 visualization placeholder -->
+        </div>
+      </section>
+
+      <section id="ai-iot">
+        <h2>AI &amp; IoT Systems</h2>
+        <p>
+          Personalized experiences blend machine learning models with sensor data from
+          connected grow operations. Interactive demos will showcase how AI recommendations
+          pair with IoT automation, while development milestones map the rollout of these
+          capabilities.
+        </p>
+        <ul>
+          <li>AI personalization for members and cultivators</li>
+          <li>IoT device integration demos</li>
+          <li>Roadmapped implementation timelines</li>
+        </ul>
+      </section>
+    </main>
+
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <!-- page‑specific scripts -->
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- extend navigation with Technology, Community, Blog, and Contact links
- add Technology & Innovation page covering infrastructure, blockchain, and AI/IoT systems
- add Community & Membership, Blog & News, and Contact & Outreach pages with placeholders for future integrations
- link home quick links to corresponding pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e80079c188331906ab51595b17956