### PR TITLE
feat: add scheduled twitter media posting

### DIFF
--- a/.github/workflows/post-media.yml
+++ b/.github/workflows/post-media.yml
@@ -1,0 +1,27 @@
+name: Post random media to X
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Post random media
+        run: node scripts/postRandomMedia.js
+        env:
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "date-fns": "^4.1.0",
         "gray-matter": "^4.0.3",
-        "slugify": "^1.6.6"
+        "slugify": "^1.6.6",
+        "twitter-api-v2": "^1.24.0"
       }
     },
     "node_modules/argparse": {
@@ -140,6 +141,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.24.0.tgz",
+      "integrity": "sha512-RDEiuNwnFirvf4c5f1sysgg0rfMQgekXgKt+/UdbNu+Bs5bJ1VbXkqKzdd2a2lPMlDVDbdGUoe2pOd4n25fFVQ==",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "generate:metadata": "node scripts/generateMetadata.js",
-    "generate:pages": "node scripts/generatePage.js"
+    "generate:pages": "node scripts/generatePage.js",
+    "post:twitter": "node scripts/postRandomMedia.js"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +16,7 @@
   "dependencies": {
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "twitter-api-v2": "^1.24.0"
   }
 }

--- a/scripts/postRandomMedia.js
+++ b/scripts/postRandomMedia.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { TwitterApi } = require('twitter-api-v2');
+
+(async () => {
+  try {
+    const mediaDir = path.join(__dirname, '..', 'media');
+    const files = fs.readdirSync(mediaDir).filter(file => /\.(jpg|png|mp4)$/i.test(file));
+    if (!files.length) {
+      console.error('No media files found in', mediaDir);
+      process.exit(1);
+    }
+
+    const chosen = files[Math.floor(Math.random() * files.length)];
+    const filePath = path.join(mediaDir, chosen);
+    const ext = path.extname(chosen).toLowerCase();
+
+    const client = new TwitterApi({
+      appKey: process.env.TWITTER_API_KEY,
+      appSecret: process.env.TWITTER_API_SECRET,
+      accessToken: process.env.TWITTER_ACCESS_TOKEN,
+      accessSecret: process.env.TWITTER_ACCESS_SECRET,
+    });
+
+    const mediaType = ext === '.mp4' ? 'video/mp4' : `image/${ext.slice(1)}`;
+    const mediaId = await client.v1.uploadMedia(fs.readFileSync(filePath), { mimeType: mediaType });
+    await client.v2.tweet({ media: { media_ids: [mediaId] } });
+    console.log(`Posted ${chosen} to Twitter`);
+  } catch (err) {
+    console.error('Failed to post media:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- run a scheduled workflow that tweets random media from `/media`
- add script using `twitter-api-v2` to upload a random file to X

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_688f55025a208331a0515df5695df732