### PR TITLE
Add placeholder page for NJ strategy guide

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -11,6 +11,7 @@
       <li><a href="/pages/lounge.html">Lounge</a></li>
       <li><a href="/pages/vision.html">Vision</a></li>
       <li><a href="/pages/investment.html">Business Plan</a></li>
+      <li><a href="/pages/nj-cannabis-guide.html">Strategy Guide</a></li>
       <li><a href="/pages/hackensack.html">Locations &amp; Licensing</a></li>
       <li><a href="/pages/forum.html">Forum</a></li>
       <li><a href="/pages/technology.html">Technology</a></li>

--- a/pages/nj-cannabis-guide.html
+++ b/pages/nj-cannabis-guide.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>NINVAX Cannabis Business Strategy & Planning Guide (New Jersey) - Ninvax</title>
+    <link rel="stylesheet" href="/styles/core.css">
+    <script src="/scripts/theme-toggle.js" defer></script>
+  </head>
+  <body class="grayscale-hover">
+    <div id="nav"></div><script src="/scripts/load-nav.js"></script>
+    <main class="container fade-slide-up">
+      <h1 class="glitch" data-text="NINVAX Cannabis Business Strategy &amp; Planning Guide (New Jersey)">NINVAX Cannabis Business Strategy &amp; Planning Guide (New Jersey)</h1>
+      <p><strong>Last Updated:</strong> August 2025<br>
+      <strong>Jurisdiction:</strong> New Jersey, USA (NJ Cannabis Regulatory Commission rules, N.J.A.C. 17:30 and related statutes)</p>
+      <section id="introduction">
+        <h2>Introduction</h2>
+        <p>New Jersey’s cannabis market offers several business avenues under the Cannabis Regulatory, Enforcement Assistance, and Marketplace Modernization (CREAMM) Act and NJ Cannabis Regulatory Commission (CRC) rules. NINVAX, as a prospective entrant, must navigate a complex regulatory landscape and choose a suitable business structure. This guide provides a comprehensive strategy and planning overview for each license class and business model allowed in New Jersey – including cultivation, manufacturing, retail, delivery, microbusiness, vertically integrated operations, and cannabis consumption areas.</p>
+        <p><em>This page is a placeholder for the full guide. The complete content will be added in a future update.</em></p>
+      </section>
+    </main>
+    <div id="footer"></div><script src="/scripts/load-footer.js"></script>
+    <script src="/scripts/scroll-animate.js"></script>
+    <script type="module" src="/scripts/grayscale-hover.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder page for the NINVAX Cannabis Business Strategy & Planning Guide (New Jersey)
- link the new guide page in site navigation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f7285b4e883318ada7dc58f41f25c